### PR TITLE
Updating example.clj for kindergarten-garden

### DIFF
--- a/kindergarten-garden/example.clj
+++ b/kindergarten-garden/example.clj
@@ -1,10 +1,10 @@
 (def default-students ["Alice" "Bob" "Charlie" "David" "Eve" "Fred" "Ginny"
                        "Harriet" "Ileana" "Joseph" "Kincaid" "Larry"])
 
-(def seeds { "G" :grass "C" :clover "R" :radishes "V" :violets })
+(def seeds { \G :grass \C :clover \R :radishes \V :violets })
 
 (defn row-to-seeds [row-string]
-  (map seeds (clojure.string/split row-string #"")))
+  (map seeds row-string))
 
 (defn garden-to-rows [garden]
   (clojure.string/split-lines garden))


### PR DESCRIPTION
The solution for this example was incorrect. The offending line in the original was line 7

```
(clojure.string/split row-string #"")
```

This doesn't give the expected result. Example:

```
(clojure.string/split "ABC" #"")
```

Result:

```
["" "A" "B" "C"]
```
