### PR TITLE
Update word count solution filename and ns

### DIFF
--- a/word-count/word_count_test.clj
+++ b/word-count/word_count_test.clj
@@ -1,28 +1,28 @@
 (ns word-count.test (:require [clojure.test :refer :all]))
-(load-file "word-count.clj")
+(load-file "word_count.clj")
 
 (deftest count-one-word
   (is (= {"word" 1}
-         (phrase/word-count "word"))))
+         (word-count/word-count "word"))))
 
 (deftest count-one-of-each
   (is (= {"one" 1 "of" 1 "each" 1}
-         (phrase/word-count "one of each"))))
+         (word-count/word-count "one of each"))))
 
 (deftest count-multiple-occurrences
   (is (= {"one" 1 "fish" 4 "two" 1 "red" 1 "blue" 1}
-         (phrase/word-count "one fish two fish red fish blue fish"))))
+         (word-count/word-count "one fish two fish red fish blue fish"))))
 
 (deftest ignore-punctuation
   (is (= {"car" 1, "carpet" 1 "as" 1 "java" 1 "javascript" 1}
-         (phrase/word-count "car : carpet as java : javascript!!&@$%^&"))))
+         (word-count/word-count "car : carpet as java : javascript!!&@$%^&"))))
 
 (deftest include-numbers
   (is (= {"testing" 2 "1" 1 "2" 1}
-         (phrase/word-count "testing, 1, 2 testing"))))
+         (word-count/word-count "testing, 1, 2 testing"))))
 
 (deftest normalize-case
   (is (= {"go" 3}
-         (phrase/word-count "go Go GO"))))
+         (word-count/word-count "go Go GO"))))
 
 (run-tests)


### PR DESCRIPTION
Hi, I had to make some changes to `word-count/word_count_test.clj` last night to be able to run the tests via a REPL and I thought it would be worthwhile submitting a PR to avoid others having to do the same.

I believe it's convention for filenames to use underscores instead of hyphens, I've also updated the referenced `ns` in `word-count/word_count_test.clj` to be `word-count` instead of `phrase` for consistency.
