### PR TITLE
Prefix leap-year? calls with ns

### DIFF
--- a/leap/leap_test.clj
+++ b/leap/leap_test.clj
@@ -1,16 +1,16 @@
 (ns leap.test (:require [clojure.test :refer :all]))
-(load-file "leap_year.clj")
+(load-file "leap.clj")
 
 (deftest vanilla-leap-year
-  (is (leap-year? 1996)))
+  (is (leap/leap-year? 1996)))
 
 (deftest any-old-year
-  (is (not (leap-year? 1997))))
+  (is (not (leap/leap-year? 1997))))
 
 (deftest century
-  (is (not (leap-year? 1900))))
+  (is (not (leap/leap-year? 1900))))
 
 (deftest exceptional-century
-  (is (leap-year? 2400)))
+  (is (leap/leap-year? 2400)))
 
 (run-tests)


### PR DESCRIPTION
Small fix to prefix calls to `leap-year?` with `leap-year` namespace to be consistent with other Clojure exercises.
