### PR TITLE
in anagram_test, a "BANANA" is not a "banana"

### DIFF
--- a/anagram/anagram_test.clj
+++ b/anagram/anagram_test.clj
@@ -27,4 +27,7 @@
 (deftest word-is-not-own-anagram
   (is (= [] (anagram/anagrams-for "banana" ["banana"]))))
 
+(deftest capital-word-is-not-own-anagram
+  (is (= [] (anagram/anagrams-for "BANANA" ["banana"]))))
+
 (run-tests)


### PR DESCRIPTION
I noticed several time that people's solution to this problem don't
include this fact. I think it should.
It also makes the problem more interesting: how to best organize
the code, to avoid using the lower-case function  everywhere in the
code, while keeping it readable.
