### PR TITLE
Make test names match assertions

### DIFF
--- a/rna-transcription/rna_transcription_test.clj
+++ b/rna-transcription/rna_transcription_test.clj
@@ -1,16 +1,16 @@
 (ns rna-transcription.test (:require [clojure.test :refer :all]))
 (load-file "rna_transcription.clj")
 
-(deftest transcribes-guanine-to-cytosine
+(deftest transcribes-cytosine-to-guanine
   (is (= "G" (rna-transcription/to-rna "C"))))
 
-(deftest transcribes-cytosine-to-guanine
+(deftest transcribes-guanine-to-cytosine
   (is (= "C" (rna-transcription/to-rna "G"))))
 
-(deftest transcribes-uracil-to-adenine
+(deftest transcribes-adenine-to-uracil
   (is (= "U" (rna-transcription/to-rna "A"))))
 
-(deftest it-transcribes-thymine-to-uracil
+(deftest it-transcribes-thymine-to-adenine
   (is (= "A" (rna-transcription/to-rna "T"))))
 
 (deftest it-transcribes-all-nucleotides


### PR DESCRIPTION
First it looked like each test name was backwards. Giving the function "C" and transcribing to "G" was named `transcribes-guanine-to-cytosine` rather than `transcribes-cytosine-to-guanine`.

Second, the assertion for "T" -> "A" appeared to be in the right order but it mentioned the wrong nucleotide.
