### PR TITLE
Normalized ciphertext chunks should be as large as can fit in the

### DIFF
--- a/crypto-square/crypto_square_test.clj
+++ b/crypto-square/crypto_square_test.clj
@@ -30,8 +30,11 @@
   (is (= "msemo aanin dninn dlaet ltshu i"
          (crypto-square/normalize-ciphertext "Madness, and then illumination."))))
 (deftest cipher-4
-  (is (= "vrela epems etpao oirpo"
+  (is (= "vrel aepe mset paoo irpo"
          (crypto-square/normalize-ciphertext "Vampires are people too!"))))
+(deftest cipher-5
+  (is (= "ageihdsednsh lsagtoonaepe lannswnccair hrditeaetnrh ueethdnatoio mbqyewdnotto aouayicdwhod nranatosaefb nldrhnhrrbef irersodirirn ieecusnonedg nailoat"
+         (crypto-square/normalize-ciphertext "All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood."))))
 
 (run-tests)
 

--- a/crypto-square/example.clj
+++ b/crypto-square/example.clj
@@ -1,3 +1,5 @@
+(ns crypto-square)
+
 (defn normalize-plaintext [input]
   (.toLowerCase (clojure.string/replace input #"[^0-9a-zA-Z]" "")))
 
@@ -21,8 +23,9 @@
                  (nth s n nil)))))
 
 (defn normalize-ciphertext [input]
-  (let [cipher (ciphertext input)]
+  (let [cipher (ciphertext input)
+        square-dims (int (Math/ceil (/ (count cipher) (square-size cipher))))]
     (apply str (interpose " "
                     (map #(apply str %1)
-                         (partition 5 5 nil cipher))))))
+                         (partition square-dims square-dims nil cipher))))))
 


### PR DESCRIPTION
smallest square, then read down the columns.
