### PR TITLE
Normalized ciphertext chunks should be as large as can fit in the square

### DIFF
--- a/crypto-square/crypto_square_test.clj
+++ b/crypto-square/crypto_square_test.clj
@@ -27,11 +27,14 @@
   (is (= "wneiaweoreneawssciliprerlneoidktcms"
          (crypto-square/ciphertext "We all know interspecies romance is weird."))))
 (deftest cipher-3
-  (is (= "msemo aanin dninn dlaet ltshu i"
+  (is (= "msemo aanin dnin ndla etlt shui"
          (crypto-square/normalize-ciphertext "Madness, and then illumination."))))
 (deftest cipher-4
-  (is (= "vrela epems etpao oirpo"
+  (is (= "vrel aepe mset paoo irpo"
          (crypto-square/normalize-ciphertext "Vampires are people too!"))))
+(deftest cipher-5
+  (is (= "ageihdsednsh lsagtoonaepe lannswnccair hrditeaetnrh ueethdnatoio mbqyewdnotto aouayicdwhod nranatosaef bnldrhnhrrb efirersodir irnieecusno nedgnailoat"
+         (crypto-square/normalize-ciphertext "All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood."))))
 
 (run-tests)
 

--- a/crypto-square/example.clj
+++ b/crypto-square/example.clj
@@ -1,3 +1,5 @@
+(ns crypto-square)
+
 (defn normalize-plaintext [input]
   (.toLowerCase (clojure.string/replace input #"[^0-9a-zA-Z]" "")))
 
@@ -21,8 +23,16 @@
                  (nth s n nil)))))
 
 (defn normalize-ciphertext [input]
-  (let [cipher (ciphertext input)]
+  (let [cipher                  (ciphertext input)
+        cipher-length           (count cipher)
+        square-max              (square-size cipher)
+        square-longest          (int (Math/ceil (/ (count cipher) square-max)))
+        square-shortest         (int (Math/floor (/ (count cipher) square-max)))
+        square-count-long-sides (- cipher-length (* square-max square-shortest))]
     (apply str (interpose " "
                     (map #(apply str %1)
-                         (partition 5 5 nil cipher))))))
-
+                         (concat (partition square-longest square-longest nil 
+                                    (take (* square-long-sides square-longest) cipher))
+                                 (partition square-shortest square-shortest nil 
+                                    (take-last (- cipher-length (* square-long-sides square-longest)) cipher))))))))
+;                         (partition square-shortest square-shortest nil cipher))))))


### PR DESCRIPTION
This fixes this and you read down the columns. 
