### PR TITLE
Update space age test to cast to float before rounding.

### DIFF
--- a/space-age/space_age_test.clj
+++ b/space-age/space_age_test.clj
@@ -5,8 +5,8 @@
 
 (defn- rounds-to
   [expected actual]
-  (is (= (Math/round (* 100 expected))
-         (Math/round (* 100 actual)))))
+  (is (= (Math/round (* 100.0 expected))
+         (Math/round (* 100.0 actual)))))
 
 (deftest age-in-earth-years
   (rounds-to 31.69 (space-age/on-earth 1000000000)))


### PR DESCRIPTION
I'm new to clojure, so when I started out I usually create a new clojure file with functions that just return nil or the input. The input here is a int, so I gave an int back. For at least an hour I was chasing my tail thinking the tests were broken when in reality they were just expecting a float in this function.

This PR just ensures the tests cast the output as a float so other new users don't chase their tail like I had.

``` clojure
user=> (Math/round 10)

IllegalArgumentException No matching method found: round  clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:80)
```
