### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,14 +1,14 @@
-#+TITLE: xClojure
+#+TITLE: Exercism Clojure Track
 
 #+ATTR_HTML: :alt Build Status
-[[https://travis-ci.org/exercism/xclojure][https://travis-ci.org/exercism/xclojure.svg]]
+[[https://travis-ci.org/exercism/clojure][https://travis-ci.org/exercism/clojure.svg]]
 
 Exercism exercises in Clojure
 
 * Contributing Guide
 Please see the [[https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data][contributing guide]].
 
-*** [[https://github.com/exercism/xclojure/tree/master/img/icon.png][Clojure icon]]
+*** [[https://github.com/exercism/clojure/tree/master/img/icon.png][Clojure icon]]
 The Clojure logo is owned by Rich Hickey.
 We are using it to identify the Clojure language itself, not any part of Exercism, which we believe to be admissible under fair use.
 The version of the logo that we are using is a black/white adaptation of the logo found on http://clojure.org.

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "clojure",
   "language": "Clojure",
-  "repository": "https://github.com/exercism/xclojure",
+  "repository": "https://github.com/exercism/clojure",
   "active": true,
   "deprecated": [
 


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1