### PR TITLE
Test the cipher for opposite direction rotation.

### DIFF
--- a/exercises/rotational-cipher/src/example.clj
+++ b/exercises/rotational-cipher/src/example.clj
@@ -1,21 +1,27 @@
 (ns rotational-cipher)
 
-(def ^:private string (partial apply str))
+(defn ^:private spinner [s a]
+  (let [a (int a)
+        spin (fn [c] (mod (+ c s) 26))]
+    (fn [c]
+      (let [c (- (int c) a)]
+        (char (+ (spin c) a))))))
 
-(def ^:private lower-case "abcdefghijklmnopqrstuvwxyz")
+(defn ^:private upper-spinner [s]
+  (spinner s \A))
 
-(def ^:private upper-case (->> lower-case (map clojure.string/upper-case) string))
+(defn ^:private lower-spinner [s]
+  (spinner s \a))
 
-(def ^:private letters (into #{} (concat lower-case upper-case)))
+(defn ^:private cipher [spin]
+  (let [upper-spin (upper-spinner spin)
+        lower-spin (lower-spinner spin)]
+    (fn [c]
+      (cond
+        (Character/isUpperCase c) (upper-spin c)
+        (Character/isLowerCase c) (lower-spin c)
+        :default c))))
 
-(defn- rotater [shift]
-  (let [encoding (->> (cycle letters)
-                      (drop (* shift 2))
-                      (take 52)
-                      (zipmap letters))]
-    (fn [char] (get encoding char char))))
-
-(defn rotate [message shift]
-  (->> message
-       (map (rotater shift))
-       string))
+(defn rotate [text spin]
+  (let [cipher (cipher spin)]
+    (apply str (map cipher text)) ))

--- a/exercises/rotational-cipher/test/rotational_cipher_test.clj
+++ b/exercises/rotational-cipher/test/rotational_cipher_test.clj
@@ -29,6 +29,9 @@
 
   (testing "rotate punctuation"
     (is (= (rotational-cipher/rotate "Let's eat, Grandma!" 21) "Gzo'n zvo, Bmviyhv!")))
+  
+  (testing "rotate in the opposite direction"
+    (is (= (rotational-cipher/rotate "b" -1) "a")))
 
   (testing "rotate all letters"
     (is (= (rotational-cipher/rotate "The quick brown fox jumps over the lazy dog." 13) "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."))))

--- a/exercises/rotational-cipher/test/rotational_cipher_test.clj
+++ b/exercises/rotational-cipher/test/rotational_cipher_test.clj
@@ -23,15 +23,25 @@
 
   (testing "rotate spaces"
     (is (= (rotational-cipher/rotate "O M G" 5) "T R L")))
-  
+
   (testing "rotate numbers"
     (is (= (rotational-cipher/rotate "Testing 1 2 3 testing" 4) "Xiwxmrk 1 2 3 xiwxmrk")))
 
   (testing "rotate punctuation"
     (is (= (rotational-cipher/rotate "Let's eat, Grandma!" 21) "Gzo'n zvo, Bmviyhv!")))
-  
+
   (testing "rotate in the opposite direction"
     (is (= (rotational-cipher/rotate "b" -1) "a")))
+
+  (testing "rotate in the opposite direction past first letter"
+    (is (= (rotational-cipher/rotate "B" -2) "Z")))
+
+  (testing "rotate in the opposite direction past letter count"
+    (is (= (rotational-cipher/rotate "B" -28) "Z")))
+
+  (testing "rotate forward then backwards the same number of steps"
+    (is (=  (rotational-cipher/rotate
+              (rotational-cipher/rotate "B" 28) -28) "B")))
 
   (testing "rotate all letters"
     (is (= (rotational-cipher/rotate "The quick brown fox jumps over the lazy dog." 13) "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."))))


### PR DESCRIPTION
A true rotational cipher does not care whether one rotates forwards or backwards.  The solution should be tested for this case.