### PR TITLE
Update tests to reflect master problem spec

### DIFF
--- a/exercises/pangram/test/pangram_test.clj
+++ b/exercises/pangram/test/pangram_test.clj
@@ -32,6 +32,7 @@
 (deftest mixed-case-and-punctuation
   (is (pangram? "\"Five quacking Zephyrs jolt my wax bed.\"")))
 
-(deftest non-ascii-characters
-  (is (pangram?
-       "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")))
+(deftest upper-and-lower-not-counted-separately
+  (is
+    (false?
+      (pangram? "the quick brown fox jumps over with lazy FX"))))


### PR DESCRIPTION
## Motivation
The [problem spec](https://github.com/exercism/problem-specifications/blob/master/exercises/pangram/canonical-data.json) for Pangram specifically indicates that the characters will be all ASCII. Additionally, there was one test from the spec missing.

## Changes
* Removed non-ascii test
* Added test for upper and lowercase characters not being counted separately