### PR TITLE
Update url in exercises to use clojure

### DIFF
--- a/exercises/accumulate/project.clj
+++ b/exercises/accumulate/project.clj
@@ -1,4 +1,4 @@
 (defproject accumulate "0.1.0-SNAPSHOT"
   :description "accumulate exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/accumulate"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/accumulate"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/acronym/project.clj
+++ b/exercises/acronym/project.clj
@@ -1,4 +1,4 @@
 (defproject acronym "0.1.0-SNAPSHOT"
   :description "acronym exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/acronym"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/acronym"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/all-your-base/project.clj
+++ b/exercises/all-your-base/project.clj
@@ -1,4 +1,4 @@
 (defproject all-your-base "0.1.0-SNAPSHOT"
   :description "all-your-base exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/all-your-base"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/all-your-base"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/allergies/project.clj
+++ b/exercises/allergies/project.clj
@@ -1,4 +1,4 @@
 (defproject allergies "0.1.0-SNAPSHOT"
   :description "allergies exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/allergies"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/allergies"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/anagram/project.clj
+++ b/exercises/anagram/project.clj
@@ -1,4 +1,4 @@
 (defproject anagram "0.1.0-SNAPSHOT"
   :description "anagram exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/anagram"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/anagram"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/atbash-cipher/project.clj
+++ b/exercises/atbash-cipher/project.clj
@@ -1,4 +1,4 @@
 (defproject atbash-cipher "0.1.0-SNAPSHOT"
   :description "atbash-cipher exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/atbash-cipher"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/atbash-cipher"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/bank-account/project.clj
+++ b/exercises/bank-account/project.clj
@@ -1,4 +1,4 @@
 (defproject bank-account "0.1.0-SNAPSHOT"
   :description "bank-account exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/bank-account"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/bank-account"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/beer-song/project.clj
+++ b/exercises/beer-song/project.clj
@@ -1,4 +1,4 @@
 (defproject beer-song "0.1.0-SNAPSHOT"
   :description "beer-song exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/beer-song"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/beer-song"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/binary-search-tree/project.clj
+++ b/exercises/binary-search-tree/project.clj
@@ -1,4 +1,4 @@
 (defproject binary-search-tree "0.1.0-SNAPSHOT"
   :description "binary-search-tree exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/binary-search-tree"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/binary-search-tree"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/binary-search/project.clj
+++ b/exercises/binary-search/project.clj
@@ -1,4 +1,4 @@
 (defproject binary-search "0.1.0-SNAPSHOT"
   :description "binary-search exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/binary-search"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/binary-search"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/binary/project.clj
+++ b/exercises/binary/project.clj
@@ -1,4 +1,4 @@
 (defproject binary "0.1.0-SNAPSHOT"
   :description "binary exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/binary"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/binary"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/bob/project.clj
+++ b/exercises/bob/project.clj
@@ -1,4 +1,4 @@
 (defproject bob "0.1.0-SNAPSHOT"
   :description "bob exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/bob"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/bob"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/bracket-push/project.clj
+++ b/exercises/bracket-push/project.clj
@@ -1,4 +1,4 @@
 (defproject bracket-push "0.1.0-SNAPSHOT"
   :description "bracket-push exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/bracket-push"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/bracket-push"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/change/project.clj
+++ b/exercises/change/project.clj
@@ -1,6 +1,6 @@
 (defproject change "0.1.0-SNAPSHOT"
   :description "[change] exercise"
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/change"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/change"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/clock/project.clj
+++ b/exercises/clock/project.clj
@@ -1,4 +1,4 @@
 (defproject clock "0.1.0-SNAPSHOT"
   :description "clock exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/clock"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/clock"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/collatz-conjecture/project.clj
+++ b/exercises/collatz-conjecture/project.clj
@@ -1,4 +1,4 @@
 (defproject collatz-conjecture "0.1.0-SNAPSHOT"
   :description "collatz-conjecture exercise"
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/collatz-conjecture"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/collatz-conjecture"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/complex-numbers/project.clj
+++ b/exercises/complex-numbers/project.clj
@@ -1,4 +1,4 @@
 (defproject complex-numbers "0.1.0-SNAPSHOT"
   :description "complex-numbers exercise"
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/complex-numbers"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/complex-numbers"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/crypto-square/project.clj
+++ b/exercises/crypto-square/project.clj
@@ -1,4 +1,4 @@
 (defproject crypto-square "0.1.0-SNAPSHOT"
   :description "crypto-square exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/crypto-square"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/crypto-square"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/difference-of-squares/project.clj
+++ b/exercises/difference-of-squares/project.clj
@@ -1,4 +1,4 @@
 (defproject difference-of-squares "0.1.0-SNAPSHOT"
   :description "difference-of-squares exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/difference-of-squares"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/difference-of-squares"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/etl/project.clj
+++ b/exercises/etl/project.clj
@@ -1,4 +1,4 @@
 (defproject etl "0.1.0-SNAPSHOT"
   :description "etl exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/etl"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/etl"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/flatten-array/project.clj
+++ b/exercises/flatten-array/project.clj
@@ -1,4 +1,4 @@
 (defproject flatten-array "0.1.0-SNAPSHOT"
   :description "flatten-array exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/flatten-array"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/flatten-array"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/gigasecond/project.clj
+++ b/exercises/gigasecond/project.clj
@@ -1,4 +1,4 @@
 (defproject gigasecond "0.1.0-SNAPSHOT"
   :description "gigasecond exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/gigasecond"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/gigasecond"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/grade-school/project.clj
+++ b/exercises/grade-school/project.clj
@@ -1,4 +1,4 @@
 (defproject grade-school "0.1.0-SNAPSHOT"
   :description "grade-school exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/grade-school"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/grade-school"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/grains/project.clj
+++ b/exercises/grains/project.clj
@@ -1,4 +1,4 @@
 (defproject grains "0.1.0-SNAPSHOT"
   :description "grains exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/grains"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/grains"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/hamming/project.clj
+++ b/exercises/hamming/project.clj
@@ -1,4 +1,4 @@
 (defproject hamming "0.1.0-SNAPSHOT"
   :description "hamming exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/hamming"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/hamming"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/hello-world/project.clj
+++ b/exercises/hello-world/project.clj
@@ -1,4 +1,4 @@
 (defproject hello-world "0.1.0-SNAPSHOT"
   :description "hello-world exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/hello-world"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/hello-world"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/hexadecimal/project.clj
+++ b/exercises/hexadecimal/project.clj
@@ -1,4 +1,4 @@
 (defproject hexadecimal "0.1.0-SNAPSHOT"
   :description "hexadecimal exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/hexadecimal"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/hexadecimal"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/isogram/project.clj
+++ b/exercises/isogram/project.clj
@@ -1,4 +1,4 @@
 (defproject isogram "0.1.0-SNAPSHOT"
   :description "isogram exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/isogram"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/isogram"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/kindergarten-garden/project.clj
+++ b/exercises/kindergarten-garden/project.clj
@@ -1,4 +1,4 @@
 (defproject kindergarten-garden "0.1.0-SNAPSHOT"
   :description "kindergarten-garden exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/kindergarten-garden"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/kindergarten-garden"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/largest-series-product/project.clj
+++ b/exercises/largest-series-product/project.clj
@@ -1,4 +1,4 @@
 (defproject largest-series-product "0.1.0-SNAPSHOT"
   :description "largest-series-product exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/largest-series-product"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/largest-series-product"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/leap/project.clj
+++ b/exercises/leap/project.clj
@@ -1,4 +1,4 @@
 (defproject leap "0.1.0-SNAPSHOT"
   :description "leap exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/leap"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/leap"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/luhn/project.clj
+++ b/exercises/luhn/project.clj
@@ -1,4 +1,4 @@
 (defproject luhn "0.1.0-SNAPSHOT"
   :description "luhn exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/luhn"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/luhn"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/meetup/project.clj
+++ b/exercises/meetup/project.clj
@@ -1,4 +1,4 @@
 (defproject meetup "0.1.0-SNAPSHOT"
   :description "meetup exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/meetup"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/meetup"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/minesweeper/project.clj
+++ b/exercises/minesweeper/project.clj
@@ -1,4 +1,4 @@
 (defproject minesweeper "0.1.0-SNAPSHOT"
   :description "minesweeper exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/minesweeper"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/minesweeper"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/nth-prime/project.clj
+++ b/exercises/nth-prime/project.clj
@@ -1,4 +1,4 @@
 (defproject nth-prime "0.1.0-SNAPSHOT"
   :description "nth-prime exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/nth-prime"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/nth-prime"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/nucleotide-count/project.clj
+++ b/exercises/nucleotide-count/project.clj
@@ -1,4 +1,4 @@
 (defproject nucleotide-count "0.1.0-SNAPSHOT"
   :description "nucleotide-count exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/nucleotide-count"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/nucleotide-count"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/octal/project.clj
+++ b/exercises/octal/project.clj
@@ -1,4 +1,4 @@
 (defproject octal "0.1.0-SNAPSHOT"
   :description "octal exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/octal"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/octal"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/pascals-triangle/project.clj
+++ b/exercises/pascals-triangle/project.clj
@@ -1,4 +1,4 @@
 (defproject pascals-triangle "0.1.0-SNAPSHOT"
   :description "pascal's triangle exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/pascals-triangle"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/pascals-triangle"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/perfect-numbers/project.clj
+++ b/exercises/perfect-numbers/project.clj
@@ -1,4 +1,4 @@
 (defproject perfect-numbers "0.1.0-SNAPSHOT"
   :description "perfect-numbers exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/perfect-numbers"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/perfect-numbers"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/phone-number/project.clj
+++ b/exercises/phone-number/project.clj
@@ -1,4 +1,4 @@
 (defproject phone-number "0.1.0-SNAPSHOT"
   :description "phone-number exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/phone-number"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/phone-number"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/pig-latin/project.clj
+++ b/exercises/pig-latin/project.clj
@@ -1,4 +1,4 @@
 (defproject pig-latin "0.1.0-SNAPSHOT"
   :description "pig latin exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/pig-latin"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/pig-latin"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/prime-factors/project.clj
+++ b/exercises/prime-factors/project.clj
@@ -1,4 +1,4 @@
 (defproject prime-factors "0.1.0-SNAPSHOT"
   :description "prime-factors exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/prime-factors"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/prime-factors"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/queen-attack/project.clj
+++ b/exercises/queen-attack/project.clj
@@ -1,4 +1,4 @@
 (defproject queen-attack "0.1.0-SNAPSHOT"
   :description "queen-attack exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/queen-attack"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/queen-attack"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/raindrops/project.clj
+++ b/exercises/raindrops/project.clj
@@ -1,4 +1,4 @@
 (defproject raindrops "0.1.0-SNAPSHOT"
   :description "raindrops exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/raindrops"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/raindrops"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/rna-transcription/project.clj
+++ b/exercises/rna-transcription/project.clj
@@ -1,4 +1,4 @@
 (defproject rna-transcription "0.1.0-SNAPSHOT"
   :description "rna-transcription exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/rna-transcription"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/rna-transcription"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/robot-name/project.clj
+++ b/exercises/robot-name/project.clj
@@ -1,4 +1,4 @@
 (defproject robot-name "0.1.0-SNAPSHOT"
   :description "robot-name exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/robot-name"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/robot-name"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/robot-simulator/project.clj
+++ b/exercises/robot-simulator/project.clj
@@ -1,4 +1,4 @@
 (defproject robot-simulator "0.1.0-SNAPSHOT"
   :description "robot-simulator exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/robot-simulator"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/robot-simulator"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/roman-numerals/project.clj
+++ b/exercises/roman-numerals/project.clj
@@ -1,4 +1,4 @@
 (defproject roman-numerals "0.1.0-SNAPSHOT"
   :description "roman-numerals exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/roman-numerals"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/roman-numerals"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/rotational-cipher/project.clj
+++ b/exercises/rotational-cipher/project.clj
@@ -1,4 +1,4 @@
 (defproject rotational-cipher "0.1.0-SNAPSHOT"
   :description "rotational cipher exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/rotational-cipher"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/rotational-cipher"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/scrabble-score/project.clj
+++ b/exercises/scrabble-score/project.clj
@@ -1,4 +1,4 @@
 (defproject scrabble-score "0.1.0-SNAPSHOT"
   :description "scrabble-score exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/scrabble-score"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/scrabble-score"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/secret-handshake/project.clj
+++ b/exercises/secret-handshake/project.clj
@@ -1,4 +1,4 @@
 (defproject secret-handshake "0.1.0-SNAPSHOT"
   :description "secret-handshake exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/secret-handshake"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/secret-handshake"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/series/project.clj
+++ b/exercises/series/project.clj
@@ -1,4 +1,4 @@
 (defproject series "0.1.0-SNAPSHOT"
   :description "series exercise"
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/series"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/series"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/sieve/project.clj
+++ b/exercises/sieve/project.clj
@@ -1,4 +1,4 @@
 (defproject sieve "0.1.0-SNAPSHOT"
   :description "sieve exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/sieve"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/sieve"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/space-age/project.clj
+++ b/exercises/space-age/project.clj
@@ -1,4 +1,4 @@
 (defproject space-age "0.1.0-SNAPSHOT"
   :description "space-age exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/space-age"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/space-age"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/spiral-matrix/project.clj
+++ b/exercises/spiral-matrix/project.clj
@@ -1,4 +1,4 @@
 (defproject spiral-matrix "0.1.0-SNAPSHOT"
   :description "spiral-matrix exercise"
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/spiral-matrix"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/spiral-matrix"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/strain/project.clj
+++ b/exercises/strain/project.clj
@@ -1,4 +1,4 @@
 (defproject strain "0.1.0-SNAPSHOT"
   :description "strain exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/strain"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/strain"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/sublist/project.clj
+++ b/exercises/sublist/project.clj
@@ -1,4 +1,4 @@
 (defproject sublist "0.1.0-SNAPSHOT"
   :description "sublist exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/sublist"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/sublist"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/sum-of-multiples/project.clj
+++ b/exercises/sum-of-multiples/project.clj
@@ -1,4 +1,4 @@
 (defproject sum-of-multiples "0.1.0-SNAPSHOT"
   :description "sum-of-multiples exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/sum-of-multiples"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/sum-of-multiples"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/triangle/project.clj
+++ b/exercises/triangle/project.clj
@@ -1,4 +1,4 @@
 (defproject triangle "0.1.0-SNAPSHOT"
   :description "triangle exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/triangle"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/triangle"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/trinary/project.clj
+++ b/exercises/trinary/project.clj
@@ -1,4 +1,4 @@
 (defproject trinary "0.1.0-SNAPSHOT"
   :description "trinary exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/trinary"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/trinary"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/word-count/project.clj
+++ b/exercises/word-count/project.clj
@@ -1,4 +1,4 @@
 (defproject word-count "0.1.0-SNAPSHOT"
   :description "word-count exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/word-count"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/word-count"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/wordy/project.clj
+++ b/exercises/wordy/project.clj
@@ -1,4 +1,4 @@
 (defproject word-count "0.1.0-SNAPSHOT"
   :description "wordy exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/exercises/wordy"
+  :url "https://github.com/exercism/clojure/tree/master/exercises/wordy"
   :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject xclojure "0.1.0"
+(defproject clojure "0.1.0"
   :description  "Exercism Exercises in Clojure"
-  :url          "https://github.com/exercism/xclojure"
+  :url          "https://github.com/exercism/clojure"
   :test-paths   ["_test"]
   :source-paths ["_src"]
   :aliases {"generate" ["run" "-m" "generator"]}


### PR DESCRIPTION
The clojure exercism repo was renamed from xclojure to clojure so this
commit updates all of the urls in project.clj files for the exercises to
reference the new name.