### PR TITLE
Fix 3-digit armstrong test description

### DIFF
--- a/exercises/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -15,7 +15,7 @@
     (is (armstrong? 153))))
 
 (deftest not-armstrong-number-100
-  (testing "Three digit number that is an Armstrong number"
+  (testing "Three digit number that is not an Armstrong number"
     (is (not (armstrong? 100)))))
 
 (deftest armstrong-number-9474


### PR DESCRIPTION
The description contradicts what is being tested and needs to be in
the negative.

:heart: 