### PR TITLE
Say - Add referance to espeak

### DIFF
--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -24,7 +24,8 @@ Some good test cases for this program are:
 ### Extension
 
 If you're on a Mac, shell out to Mac OS X's `say` program to talk out
-loud.
+loud. If you're on Linux or Windows eSpeakNG may be available with the command
+`espeak`.
 
 ## Step 2
 


### PR DESCRIPTION
I really liked the challenge to use text-to-speech software to say the numbers out loud, but since the
README says "for Mac Users" I skimmed past it at first without paying attention. I'm glad I took
the time to find an alternative, and I wanted to make sure others will be made aware of it too, so I added a reference to espeak for Windows and Linux users.