### PR TITLE
Add an ISBN Verifier test case for short ISBN

### DIFF
--- a/exercises/isbn-verifier/test/isbn_verifier_test.clj
+++ b/exercises/isbn-verifier/test/isbn_verifier_test.clj
@@ -32,6 +32,9 @@
 (deftest too-long-isbn-and-no-dashes
   (is (= false (isbn? "3598215078X"))))
 
+(deftest too-short-isbn
+  (is (= false (isbn? "00"))))
+
 (deftest isbn-without-check-digit
   (is (= false (isbn? "3-598-21507"))))
 


### PR DESCRIPTION
If your code verify the isbn length to be only *less than or equal to* 10, it will accept some ISBN with less than 10 digits which still satisfy other rules, being "00" a case which could be considered ISBN by some "almost correct" solutions missing this consideration.

I.e: http://exercism.io/submissions/f2fac1e79bf441e08afecd196ec0a442