### PR TITLE
Add default args to stub files

### DIFF
--- a/exercises/anagram/src/anagram.clj
+++ b/exercises/anagram/src/anagram.clj
@@ -1,5 +1,5 @@
 (ns anagram)
 
-(defn anagrams-for [] ;; <- arglist goes here
+(defn anagrams-for [word prospect-list] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/armstrong-numbers/src/armstrong_numbers.clj
+++ b/exercises/armstrong-numbers/src/armstrong_numbers.clj
@@ -1,5 +1,5 @@
 (ns armstrong-numbers)
 
-(defn armstrong? [n] ;; <- arglist goes here
+(defn armstrong? [num] ;; <- arglist goes here
   ;; your code goes here
   )

--- a/exercises/beer-song/src/beer_song.clj
+++ b/exercises/beer-song/src/beer_song.clj
@@ -2,7 +2,7 @@
 
 (defn verse
  "Returns the nth verse of the song."
- [n])
+ [num])
 
 (defn sing
   "Given a start and an optional end, returns all verses in this interval. If

--- a/exercises/bob/src/bob.clj
+++ b/exercises/bob/src/bob.clj
@@ -1,5 +1,5 @@
 (ns bob)
 
-(defn response-for [] ;; <- arglist goes here
+(defn response-for [s] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/clock/src/clock.clj
+++ b/exercises/clock/src/clock.clj
@@ -1,13 +1,13 @@
 (ns clock)
 
-(defn clock->string [] ;; <- arglist goes here
+(defn clock->string [clock] ;; <- arglist goes here
   ;; your code goes here
 )
 
-(defn clock [] ;; <- arglist goes here
+(defn clock [hours minutes] ;; <- arglist goes here
   ;; your code goes here
 )
 
-(defn add-time [] ;; <- arglist goes here
+(defn add-time [clock time] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/collatz-conjecture/src/collatz_conjecture.clj
+++ b/exercises/collatz-conjecture/src/collatz_conjecture.clj
@@ -1,5 +1,5 @@
 (ns collatz-conjecture)
 
-(defn collatz [n] ;; <- arglist goes here
+(defn collatz [num] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/etl/src/etl.clj
+++ b/exercises/etl/src/etl.clj
@@ -1,5 +1,5 @@
 (ns etl)
 
-(defn transform [] ;; <- arglist goes here
+(defn transform [source] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/flatten-array/src/flatten_array.clj
+++ b/exercises/flatten-array/src/flatten_array.clj
@@ -1,5 +1,5 @@
 (ns flatten-array)
 
-(defn flatten [] ;; <- arglist goes here
+(defn flatten [arr] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/grade-school/src/grade_school.clj
+++ b/exercises/grade-school/src/grade_school.clj
@@ -1,13 +1,13 @@
 (ns grade-school)
 
-(defn grade []  ;; <- arglist goes here
+(defn grade [school grade]  ;; <- arglist goes here
     ;; your code goes here
 )
 
-(defn add []  ;; <- arglist goes here
+(defn add [school name grade]  ;; <- arglist goes here
     ;; your code goes here
 )
 
-(defn sorted []  ;; <- arglist goes here
+(defn sorted [school]  ;; <- arglist goes here
     ;; your code goes here
 )

--- a/exercises/hamming/src/hamming.clj
+++ b/exercises/hamming/src/hamming.clj
@@ -1,5 +1,5 @@
 (ns hamming)
 
-(defn distance [] ; <- arglist goes here
-  ;; your code goes here 
+(defn distance [strand1 strand2] ; <- arglist goes here
+  ;; your code goes here
 )

--- a/exercises/leap/src/leap.clj
+++ b/exercises/leap/src/leap.clj
@@ -1,5 +1,5 @@
 (ns leap)
 
-(defn leap-year? [] ;; <- argslist goes here
+(defn leap-year? [year] ;; <- argslist goes here
   ;; your code goes here
 )

--- a/exercises/nucleotide-count/src/nucleotide_count.clj
+++ b/exercises/nucleotide-count/src/nucleotide_count.clj
@@ -1,9 +1,9 @@
 (ns nucleotide-count)
 
-(defn count [] ;; <- Arglist goes here
+(defn count [nucleotide strand] ;; <- Arglist goes here
   ;; your code goes here
   )
 
-(defn nucleotide-counts [] ;; <- Arglist goes here
+(defn nucleotide-counts [strand] ;; <- Arglist goes here
   ;; your code goes here
   )

--- a/exercises/phone-number/src/phone_number.clj
+++ b/exercises/phone-number/src/phone_number.clj
@@ -1,13 +1,13 @@
 (ns phone-number)
 
-(defn number [] ;; <- arglist goes here
+(defn number [num-string] ;; <- arglist goes here
       ;; your code goes here
       )
 
-(defn area-code [] ;; <- arglist goes here
+(defn area-code [num-string] ;; <- arglist goes here
   ;; your code goes here
   )
 
-(defn pretty-print [] ;; <- arglist goes here
+(defn pretty-print [num-string] ;; <- arglist goes here
   ;; your code goes here
   )

--- a/exercises/reverse-string/src/reverse_string.clj
+++ b/exercises/reverse-string/src/reverse_string.clj
@@ -1,5 +1,5 @@
 (ns reverse-string)
 
-(defn reverse-string [] ;; <- arglist goes here
+(defn reverse-string [s] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/rna-transcription/src/rna_transcription.clj
+++ b/exercises/rna-transcription/src/rna_transcription.clj
@@ -1,5 +1,5 @@
 (ns rna-transcription)
 
-(defn to-rna [] ;; <- arglist goes here
+(defn to-rna [dna] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/robot-name/src/robot_name.clj
+++ b/exercises/robot-name/src/robot_name.clj
@@ -4,10 +4,10 @@
   ;; your code goes here
   )
 
-(defn robot-name [] ;; <- arglist goes here
+(defn robot-name [robot] ;; <- arglist goes here
       ;; your code goes here
       )
 
-(defn reset-name [] ;; <- arglist goes here
+(defn reset-name [robot] ;; <- arglist goes here
   ;; your code goes here
   )

--- a/exercises/run-length-encoding/src/run_length_encoding.clj
+++ b/exercises/run-length-encoding/src/run_length_encoding.clj
@@ -2,10 +2,10 @@
 
 (defn run-length-encode
   "encodes a string with run-length-encoding"
-  [s]
+  [plain-text]
   )
 
 (defn run-length-decode
   "decodes a run-length-encoded string"
-  [s]
+  [cipher-text]
   )

--- a/exercises/say/src/say.clj
+++ b/exercises/say/src/say.clj
@@ -1,5 +1,5 @@
 (ns say)
 
-(defn number [] ;; <- arglist goes here
+(defn number [num] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/series/src/series.clj
+++ b/exercises/series/src/series.clj
@@ -1,5 +1,5 @@
 (ns series)
 
-(defn slices [string n] ;; <- arglist goes here
+(defn slices [string length] ;; <- arglist goes here
   ;; your code goes here
   )

--- a/exercises/sublist/src/sublist.clj
+++ b/exercises/sublist/src/sublist.clj
@@ -1,5 +1,5 @@
 (ns sublist)
 
-(defn classify [] ;; <- arglist goes here
+(defn classify [list1 list2] ;; <- arglist goes here
       ;; your code goes here
       )

--- a/exercises/two-fer/src/two_fer.clj
+++ b/exercises/two-fer/src/two_fer.clj
@@ -1,5 +1,5 @@
 (ns two-fer)
 
-(defn two-fer [] ;; <- arglist goes here
+(defn two-fer [name] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/word-count/src/word_count.clj
+++ b/exercises/word-count/src/word_count.clj
@@ -1,5 +1,5 @@
 (ns word-count)
 
-(defn word-count [] ;; <- arglist goes here
+(defn word-count [s] ;; <- arglist goes here
   ;; your code goes here
 )


### PR DESCRIPTION
I added, or updated, default arguments in the first ~25 exercises' stub files. I tried to make the argument names input format and/or the scenario of the exercise, except in cases where it seemed completely redundant to do so (i.e. when a `num` really is just a `num`). Of course I'm open to feedback and will be happy to make changes as necessary.