### PR TITLE
updated link to 4Clojure in RESOURCES.md

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -6,4 +6,3 @@ learning Clojure; here is a short list.
 - [Learn Clojure](http://learn-clojure.com/)
 - [Clojure Docs](https://clojuredocs.org/)
 - [Brave Clojure](http://www.braveclojure.com/)
-- [4Clojure](https://www.4clojure.com/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -6,3 +6,4 @@ learning Clojure; here is a short list.
 - [Learn Clojure](http://learn-clojure.com/)
 - [Clojure Docs](https://clojuredocs.org/)
 - [Brave Clojure](http://www.braveclojure.com/)
+- [4Clojure](http://www.4clojure.com/)


### PR DESCRIPTION
https://www.4clojure.com/ does not answer properly:

```
$ curl -v -k https://www.4clojure.com/
*   Trying 173.255.221.96...
* TCP_NODELAY set
* Connected to www.4clojure.com (173.255.221.96) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol
* stopped the pause stream!
* Closing connection 0
curl: (35) error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol
```