### PR TITLE
Adding a test for the armstrong number 21897142587612075.

### DIFF
--- a/exercises/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -33,3 +33,7 @@
 (deftest not-armstrong-number-9926314
   (testing "Seven digit number that is not an Armstrong number"
     (is (not (armstrong? 9926314)))))
+
+(deftest armstrong-number-21897142587612075
+  (testing "Seventeen digit number that is an Armstrong number"
+    (is (armstrong? 21897142587612075))))


### PR DESCRIPTION
I would like to propose this change from my experience in mentoring this exercise.

Many students seem to implement this exercise using floating point
arithmetics `(Math/pow)` comparing the result with the equal operator
afterwards.

I think we can agree, that comparing floating point numbers for strict
equality is not a good thing. But our tests had no case, where this
actually mattered.

I was searching for the lowest armstrong number, where this actually
matters and found 21897142587612075 to be a good candidate. The exercise
implemented in floating point arithmetics doesn't pass this added test,
while implementing it in integer arithmetics let all test pass.