### PR TITLE
difference-of-squares: renamed square-of-sums to square-of-sum

### DIFF
--- a/exercises/difference-of-squares/src/difference_of_squares.clj
+++ b/exercises/difference-of-squares/src/difference_of_squares.clj
@@ -8,6 +8,6 @@
   ;; your code goes here
 )
 
-(defn square-of-sums [] ;; <- arglist goes here
+(defn square-of-sum [] ;; <- arglist goes here
   ;; your code goes here
 )

--- a/exercises/difference-of-squares/src/example.clj
+++ b/exercises/difference-of-squares/src/example.clj
@@ -5,8 +5,8 @@
 (defn sum-of-squares [n]
   (sum (map #(int (Math/pow % 2)) (range 0 (inc n)))))
 
-(defn square-of-sums [n]
+(defn square-of-sum [n]
   (int (Math/pow (sum (range 0 (inc n))) 2)))
 
 (defn difference [x]
-  (- (square-of-sums x) (sum-of-squares x)))
+  (- (square-of-sum x) (sum-of-squares x)))

--- a/exercises/difference-of-squares/test/difference_of_squares_test.clj
+++ b/exercises/difference-of-squares/test/difference_of_squares_test.clj
@@ -2,29 +2,29 @@
   (:require [clojure.test :refer [deftest is]]
             [difference-of-squares :as dos]))
 
-(deftest square-of-sums-to-5
-  (is (= 225 (dos/square-of-sums 5))))
+(deftest square-of-sum-to-5
+  (is (= 225 (dos/square-of-sum 5))))
 
 (deftest sum-of-squares-to-5
   (is (= 55 (dos/sum-of-squares 5))))
 
-(deftest difference-of-sums-to-5
+(deftest difference-of-squares-to-5
   (is (= 170 (dos/difference 5))))
 
-(deftest square-of-sums-to-10
-  (is (= 3025 (dos/square-of-sums 10))))
+(deftest square-of-sum-to-10
+  (is (= 3025 (dos/square-of-sum 10))))
 
 (deftest sum-of-squares-to-10
   (is (= 385 (dos/sum-of-squares 10))))
 
-(deftest difference-of-sums-to-10
+(deftest difference-of-squares-to-10
   (is (= 2640 (dos/difference 10))))
 
-(deftest square-of-sums-to-100
-  (is (= 25502500 (dos/square-of-sums 100))))
+(deftest square-of-sum-to-100
+  (is (= 25502500 (dos/square-of-sum 100))))
 
 (deftest sum-of-squares-to-100
   (is (= 338350 (dos/sum-of-squares 100))))
 
-(deftest difference-of-sums-to-100
+(deftest difference-of-squares-to-100
   (is (= 25164150 (dos/difference 100))))


### PR DESCRIPTION
In exercise "difference-of-sums", renamed `square-of-sums` to `square-of-sum` and `difference-of-sums` to `difference-of-squares`.