### PR TITLE
Switched order of args to = for clearer test failure messages

### DIFF
--- a/exercises/clock/test/clock_test.clj
+++ b/exercises/clock/test/clock_test.clj
@@ -6,112 +6,112 @@
 
   (testing "on the hour"
     (let [test-clock (clock->string (clock 8 0))]
-      (is (= test-clock "08:00"))))
+      (is (= "08:00" test-clock))))
   (testing "past the hour"
     (let [test-clock (clock->string (clock 11 9))]
-      (is (= test-clock "11:09"))))
+      (is (= "11:09" test-clock))))
   (testing "midnight is zero hours"
     (let [test-clock (clock->string (clock 24 0))]
-      (is (= test-clock "00:00"))))
+      (is (= "00:00" test-clock))))
   (testing "hour rolls over"
     (let [test-clock (clock->string (clock 25 0))]
-      (is (= test-clock "01:00"))))
+      (is (= "01:00" test-clock))))
   (testing "hour rolls over continuously"
     (let [test-clock (clock->string (clock 100 0))]
-      (is (= test-clock "04:00"))))
+      (is (= "04:00" test-clock))))
   (testing "sixty minutes is next hour"
     (let [test-clock (clock->string (clock 1 60))]
-      (is (= test-clock "02:00"))))
+      (is (= "02:00" test-clock))))
   (testing "minutes roll over"
     (let [test-clock (clock->string (clock 0 160))]
-      (is (= test-clock "02:40"))))
+      (is (= "02:40" test-clock))))
   (testing "minutes roll over continuously"
     (let [test-clock (clock->string (clock 0 1723))]
-      (is (= test-clock "04:43"))))
+      (is (= "04:43" test-clock))))
   (testing "hour and minutes roll over"
     (let [test-clock (clock->string (clock 25 160))]
-      (is (= test-clock "03:40"))))
+      (is (= "03:40" test-clock))))
   (testing "hour and minutes roll over continuously"
     (let [test-clock (clock->string (clock 201 3001))]
-      (is (= test-clock "11:01"))))
+      (is (= "11:01" test-clock))))
   (testing "hour and minutes roll over to exactly midnight"
     (let [test-clock (clock->string (clock 72 8640))]
-      (is (= test-clock "00:00"))))
+      (is (= "00:00" test-clock))))
   (testing "negative hour"
     (let [test-clock (clock->string (clock -1 15))]
-      (is (= test-clock "23:15"))))
+      (is (= "23:15" test-clock))))
   (testing "negative hour rolls over"
     (let [test-clock (clock->string (clock -25 0))]
-      (is (= test-clock "23:00"))))
+      (is (= "23:00" test-clock))))
   (testing "negative hour rolls over continuously"
     (let [test-clock (clock->string (clock -91 0))]
-      (is (= test-clock "05:00"))))
+      (is (= "05:00" test-clock))))
   (testing "negative minutes"
     (let [test-clock (clock->string (clock 1 -40))]
-      (is (= test-clock "00:20"))))
+      (is (= "00:20" test-clock))))
   (testing "negative minutes roll over"
     (let [test-clock (clock->string (clock 1 -160))]
-      (is (= test-clock "22:20"))))
+      (is (= "22:20" test-clock))))
   (testing "negative minutes roll over continuously"
     (let [test-clock (clock->string (clock 1 -4820))]
-      (is (= test-clock "16:40"))))
+      (is (= "16:40" test-clock))))
   (testing "negative hour and minutes both roll over"
     (let [test-clock (clock->string (clock -25 -160))]
-      (is (= test-clock "20:20"))))
+      (is (= "20:20" test-clock))))
   (testing "negative hour and minutes both roll over continuously"
     (let [test-clock (clock->string (clock -121 -5810))]
-      (is (= test-clock "22:10")))))
+      (is (= "22:10" test-clock)))))
 
 (deftest add-time-test
 
   (testing "add minutes"
     (let [test-clock (clock->string (add-time (clock 10 0) 3))]
-      (is (= test-clock "10:03"))))
+      (is (= "10:03" test-clock))))
   (testing "add no minutes"
     (let [test-clock (clock->string (add-time (clock 6 41) 0))]
-      (is (= test-clock "06:41"))))
+      (is (= "06:41" test-clock))))
   (testing "add to next hour"
     (let [test-clock (clock->string (add-time (clock 0 45) 40))]
-      (is (= test-clock "01:25"))))
+      (is (= "01:25" test-clock))))
   (testing "add more than one hour"
     (let [test-clock (clock->string (add-time (clock 10 0) 61))]
-      (is (= test-clock "11:01"))))
+      (is (= "11:01" test-clock))))
   (testing "add more than two hours with carry"
     (let [test-clock (clock->string (add-time (clock 0 45) 160))]
-      (is (= test-clock "03:25"))))
+      (is (= "03:25" test-clock))))
   (testing "add across midnight"
     (let [test-clock (clock->string (add-time (clock 23 59) 2))]
-      (is (= test-clock "00:01"))))
+      (is (= "00:01" test-clock))))
   (testing "add more than one day (1500 min = 25 hrs)"
     (let [test-clock (clock->string (add-time (clock 5 32) 1500))]
-      (is (= test-clock "06:32"))))
+      (is (= "06:32" test-clock))))
   (testing "add more than two days"
     (let [test-clock (clock->string (add-time (clock 1 1) 3500))]
-      (is (= test-clock "11:21"))))
+      (is (= "11:21" test-clock))))
   (testing "subtract minutes"
     (let [test-clock (clock->string (add-time (clock 10 3) -3))]
-      (is (= test-clock "10:00"))))
+      (is (= "10:00" test-clock))))
   (testing "subtract to previous hour"
     (let [test-clock (clock->string (add-time (clock 10 3) -30))]
-      (is (= test-clock "09:33"))))
+      (is (= "09:33" test-clock))))
   (testing "subtract more than an hour"
     (let [test-clock (clock->string (add-time (clock 10 3) -70))]
-      (is (= test-clock "08:53"))))
+      (is (= "08:53" test-clock))))
   (testing "subtract across midnight"
     (let [test-clock (clock->string (add-time (clock 0 3) -4))]
-      (is (= test-clock "23:59"))))
+      (is (= "23:59" test-clock))))
   (testing "subtract more than two hours"
     (let [test-clock (clock->string (add-time (clock 0 0) -160))]
-      (is (= test-clock "21:20"))))
+      (is (= "21:20" test-clock))))
   (testing "subtract more than two hours with borrow"
     (let [test-clock (clock->string (add-time (clock 6 15) -160))]
-      (is (= test-clock "03:35"))))
+      (is (= "03:35" test-clock))))
   (testing "subtract more than one day (1500 min = 25 hrs)"
     (let [test-clock (clock->string (add-time (clock 5 32) -1500))]
-      (is (= test-clock "04:32"))))
+      (is (= "04:32" test-clock))))
   (testing "subtract more than two days"
     (let [test-clock (clock->string (add-time (clock 2 20) -3000))]
-      (is (= test-clock "00:20")))))
+      (is (= "00:20" test-clock)))))
 
 (deftest equal-clock-test
   (testing "clocks with same time"


### PR DESCRIPTION
Now the values displayed by clojure.test for expected and actual match what is being returned by the implementation (actual) versus what is supplied by the test (expected)