### PR TITLE
Redid Proverb Exercise

### DIFF
--- a/exercises/proverb/src/example.clj
+++ b/exercises/proverb/src/example.clj
@@ -1,15 +1,15 @@
 (ns proverb
   (:require [clojure.string :as str]))
 
-(def subjects ["nail" "shoe" "horse" "rider" "message" "battle" "kingdom"])
-
-(def last-line "And all for the want of a nail.")
+(def last-line "And all for the want of a %s.")
 
 (defn- line [[cause-subject effect-subject]]
   (format "For want of a %s the %s was lost." cause-subject effect-subject))
 
-(def proverb (->> subjects
-                  (partition 2 1)
-                  (map line)
-                  (#(conj (vec %) last-line))
-                  (str/join "\n")))
+(defn recite [subjects]
+  (if (empty? subjects) ""
+    (->> subjects
+    (partition 2 1)
+    (map line)
+    (#(conj (vec %) (format last-line (first subjects))))
+    (str/join "\n"))))

--- a/exercises/proverb/src/proverb.clj
+++ b/exercises/proverb/src/proverb.clj
@@ -1,5 +1,5 @@
 (ns proverb)
 
-(defn proverb [] ;; <- arglist goes here
+(defn recite [] ;; <- arglist goes here
     ;; your code goes here
 )

--- a/exercises/proverb/src/proverb.clj
+++ b/exercises/proverb/src/proverb.clj
@@ -1,3 +1,5 @@
 (ns proverb)
 
-(def proverb "")
+(defn proverb [] ;; <- arglist goes here
+    ;; your code goes here
+)

--- a/exercises/proverb/test/proverb_test.clj
+++ b/exercises/proverb/test/proverb_test.clj
@@ -1,10 +1,33 @@
 (ns proverb-test
   (:require [clojure.test :refer [deftest is]]
-            [proverb :refer [proverb]]
+            [proverb :refer [recite]]
             [clojure.string :as str]))
 
-(deftest full-text-is-correct
-  (is (= proverb
+(deftest zero-pieces
+  (is (=
+        (recite ())
+        "")))
+      
+(deftest one-piece
+  (is (=
+        (recite '("nail"))
+        "And all for the want of a nail.")))
+
+(deftest two-pieces
+  (is (=
+        (recite '("nail" "shoe"))
+        (str/join "\n" ["For want of a nail the shoe was lost."
+                        "And all for the want of a nail."]))))
+
+(deftest three-pieces
+  (is (=
+        (recite '("nail" "shoe" "horse"))
+        (str/join "\n" ["For want of a nail the shoe was lost."
+                        "For want of a shoe the horse was lost."
+                        "And all for the want of a nail."]))))
+
+(deftest full-proverb
+  (is (= (recite '("nail" "shoe" "horse" "rider" "message" "battle" "kingdom"))
          (str/join "\n" ["For want of a nail the shoe was lost."
                          "For want of a shoe the horse was lost."
                          "For want of a horse the rider was lost."
@@ -12,3 +35,11 @@
                          "For want of a message the battle was lost."
                          "For want of a battle the kingdom was lost."
                          "And all for the want of a nail."]))))
+
+(deftest four-pieces-modernized
+  (is (=
+        (recite '("pin" "gun" "soldier" "battle"))
+        (str/join "\n" ["For want of a pin the gun was lost."
+                        "For want of a gun the soldier was lost."
+                        "For want of a soldier the battle was lost."
+                        "And all for the want of a pin."]))))


### PR DESCRIPTION
Proverb's test suite currently tests a single imported variable `proverb` to see if it matches the full text of the proverb, and does nothing else. The template for writing a solution doesn't even suggest that you use a function of any sort, simply giving you `(def proverb )`. This is inconsistent with both the README and the canonical test data for the exercise. I have corrected this problem, and look forward to submitting my updated solution.