### PR TITLE
Add exercise ratings

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
       "uuid": "d3bcad28-db03-4f6c-a85d-9f2d01331e88",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -51,7 +51,7 @@
       "uuid": "c2100dff-4d18-4fcb-9035-6c57eddd6d37",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -59,7 +59,7 @@
       "uuid": "04a6c1d6-6cce-4c87-a34b-23fdd9baf70d",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -67,7 +67,7 @@
       "uuid": "e6411d18-d9b9-48fa-8ee6-0df8c13d3dee",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -75,7 +75,7 @@
       "uuid": "3ab74232-11f5-4efd-82ac-e7c4129c7ff4",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -83,7 +83,7 @@
       "uuid": "04ac2bd0-504c-4faa-912e-d2111b46123c",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -91,7 +91,7 @@
       "uuid": "31aa2618-b971-44ff-9799-761fdec53b87",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -99,7 +99,7 @@
       "uuid": "c14ef548-c5f6-43a9-84e2-c7238705fc8e",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -107,7 +107,7 @@
       "uuid": "c14ef548-c5f6-43a9-84e2-c7248705fc8e",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "math"
       ]
@@ -117,7 +117,7 @@
       "uuid": "c34af548-c5f6-43a9-84e2-c4166605fc8e",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -125,7 +125,7 @@
       "uuid": "66d97ae9-36ac-47c6-8b9f-e77ce498fc70",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -133,7 +133,7 @@
       "uuid": "60004bf0-e551-4bfc-bda9-49c5611811c4",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -141,7 +141,7 @@
       "uuid": "84ce66e5-6091-4078-9921-c0b8ccabc86f",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -149,7 +149,7 @@
       "uuid": "8e722baf-bbf9-445f-9adb-b21db88b5132",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 5,
       "topics": null
     },
     {
@@ -157,7 +157,7 @@
       "uuid": "f4cf3676-4399-4d1c-b21f-8e735c7af8cc",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -165,7 +165,7 @@
       "uuid": "95580d10-92db-4809-b5e7-4085319d19e9",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "math"
       ]
@@ -175,7 +175,7 @@
       "uuid": "3ce7ad7d-61ef-4a71-b87a-8c1b45c758b6",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -183,7 +183,7 @@
       "uuid": "0cde8a62-412a-45cc-b16e-4b31057cab74",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -191,7 +191,7 @@
       "uuid": "c51658c1-7cdb-4a45-8d4d-2a370b655362",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -199,7 +199,7 @@
       "uuid": "11450b65-628d-4890-a668-7031de985f5c",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -207,7 +207,7 @@
       "uuid": "dabe93c3-038c-4c6f-8a2e-f50acf130b8f",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -215,7 +215,7 @@
       "uuid": "36f47cc4-0c5e-4edc-b109-c9e007b7b1f8",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -223,7 +223,7 @@
       "uuid": "097edd69-91b5-4a71-b197-a9c14b61c4ce",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
         "math"
       ]
@@ -233,7 +233,7 @@
       "uuid": "1657cd1a-f3d8-475f-824f-31ba4d8e229a",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": null
     },
     {
@@ -241,7 +241,7 @@
       "uuid": "735e991b-f736-4ca2-80db-f94e20aa2319",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -249,7 +249,7 @@
       "uuid": "27b44b76-5e4f-4711-bce0-869e372636dd",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -257,7 +257,7 @@
       "uuid": "23498ff3-310e-41b0-b15e-52fec2f2bfcb",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -265,7 +265,7 @@
       "uuid": "74f7eacd-d3de-4467-85b2-8590ba1f28ce",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -273,7 +273,7 @@
       "uuid": "01afac67-ff81-432e-b2a0-63f4540f2eb5",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -281,7 +281,7 @@
       "uuid": "04d0369f-b0e5-4c00-a0f7-1b86eefba484",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -289,7 +289,7 @@
       "uuid": "4c59731d-165a-43e1-9917-16131dadbbac",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
         "math"
       ]
@@ -299,7 +299,7 @@
       "uuid": "d32f41d4-e1b1-4daf-8ddc-a2ab9ee07c98",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
         "math"
       ]
@@ -309,7 +309,7 @@
       "uuid": "d42g42d7-21b1-4daf-8ddc-a2ab9ee07c98",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": [
         "recursivity"
       ]
@@ -319,7 +319,7 @@
       "uuid": "068a0997-d333-48cb-a82a-c5082e85115d",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
         "math"
       ]
@@ -329,7 +329,7 @@
       "uuid": "c1113f92-df4d-4d04-865f-20b8b2c56205",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -337,7 +337,7 @@
       "uuid": "810803c7-4480-4e11-b848-d56477ba9d08",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": null
     },
     {
@@ -345,7 +345,7 @@
       "uuid": "db1a86fb-2f04-4afe-9e45-00b539c86b63",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": [
         "math"
       ]
@@ -355,7 +355,7 @@
       "uuid": "ad08dcef-14f7-406d-b3a5-4b5aad37ebf1",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -363,7 +363,7 @@
       "uuid": "47266422-622e-4e20-b597-e85ab7bd3046",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -371,7 +371,7 @@
       "uuid": "e6848f52-a6b5-4669-9b50-beedfd3ebe2f",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 7,
       "topics": null
     },
     {
@@ -379,7 +379,7 @@
       "uuid": "8b90d4c5-0d53-4664-afba-c4ed1c865e77",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": null
     },
     {
@@ -387,7 +387,7 @@
       "uuid": "9c8c4689-4990-4266-a02e-2dcb9fa32402",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
         "math"
       ]
@@ -397,7 +397,7 @@
       "uuid": "a7e1d0a1-feb5-4a55-93c7-e7f81a39238c",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "math"
       ]
@@ -407,7 +407,7 @@
       "uuid": "910adfb9-be3e-45ef-af4c-facba7825cfd",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 5,
       "topics": [
         "math"
       ]
@@ -417,7 +417,7 @@
       "uuid": "5f62a862-f65e-4af0-a15d-5aa1fdb4f970",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 5,
       "topics": null
     },
     {
@@ -425,7 +425,7 @@
       "uuid": "5288c0fb-a90d-4f71-b525-e9a7b687aaf2",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -433,7 +433,7 @@
       "uuid": "e4f94fe1-7258-4e55-94c8-756a8080f898",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 6,
       "topics": null
     },
     {
@@ -441,7 +441,7 @@
       "uuid": "0bc807ef-60b8-49d9-9428-0060bc5517a9",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 7,
       "topics": null
     },
     {
@@ -449,7 +449,7 @@
       "uuid": "73cdbbd8-04a6-42ba-aeea-1f1c8d53af70",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -457,7 +457,7 @@
       "uuid": "62f3cbcb-2503-472f-9544-50e05e368949",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -465,7 +465,7 @@
       "uuid": "254199d8-8add-470f-a8fc-8ec9ffc54dd1",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": [
         "math"
       ]
@@ -475,7 +475,7 @@
       "uuid": "8ede90b5-d1ad-41c3-8474-2ffaea39e7e4",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": [
         "math"
       ]
@@ -485,7 +485,7 @@
       "uuid": "b55eefa5-dce6-46fb-8c0e-4c476cc871ce",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "math"
       ]
@@ -495,7 +495,7 @@
       "uuid": "eec9ea9a-fa32-4ea2-831e-0caccbca208b",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": [
         "math"
       ]
@@ -505,7 +505,7 @@
       "uuid": "ee9b837b-ea2f-4c77-9a3d-3d0007b9ae88",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 10,
       "topics": null
     },
     {
@@ -513,7 +513,7 @@
       "uuid": "c8ebc25b-17b9-44a9-8cbe-df2c2eb6e2d6",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 7,
       "topics": null
     },
     {
@@ -521,7 +521,7 @@
       "uuid": "2d35d9b3-5cff-4e68-a861-1461b32e22ba",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 7,
       "topics": null
     },
     {
@@ -529,7 +529,7 @@
       "uuid": "6fd886e5-94b0-4938-9f48-f4c6850027a0",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -537,7 +537,7 @@
       "uuid": "398f65f2-2324-4b08-945d-a9fbd62d1a41",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -545,7 +545,7 @@
       "uuid": "4a2033a7-5579-49ac-94d7-8693cee45381",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 6,
       "topics": null
     },
     {
@@ -553,7 +553,7 @@
       "uuid": "1fc5c2e9-2851-4735-8fde-612a8c054a5a",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -561,7 +561,7 @@
       "uuid": "e14a4261-c84f-417e-841e-29ff6f1f533d",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -569,7 +569,7 @@
       "uuid": "d380de85-4d35-4342-9b88-7402deea2869",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "math"
       ]
@@ -579,7 +579,7 @@
       "uuid": "6768b55e-bab3-4e55-ac71-ddda0bd16298",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -587,7 +587,7 @@
       "uuid": "2cc37c2a-7e6c-49ba-8b30-2ff8c9d818c2",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -595,7 +595,7 @@
       "uuid": "622823dc-ee47-42a0-acc6-190de4541625",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": null
     },
     {
@@ -603,7 +603,7 @@
       "uuid": "f3971f71-08c9-4e36-a69e-5bd7fe070b07",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 5,
       "topics": null
     },
     {
@@ -611,7 +611,7 @@
       "uuid": "c4b7120c-a7c5-4a39-a08e-8d4fb9861a27",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "pattern_matching",
         "strings"
@@ -622,7 +622,7 @@
       "uuid": "c8ba6ce5-9a7e-4c1c-8044-bb18a0d6ad39",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 3,
       "topics": null
     },
     {
@@ -630,7 +630,7 @@
       "uuid": "7df7ff1c-74ab-4f4e-aaf0-257b6e1cbc18",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 7,
       "topics": null
     },
     {
@@ -638,7 +638,7 @@
       "uuid": "db6162c0-adff-401e-9dd6-a0322ca10dcf",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 4,
       "topics": null
     },
     {
@@ -646,7 +646,7 @@
       "uuid": "987438e8-1db3-447a-a243-e67c7591709d",
       "core": false,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 9,
       "topics": null
     }
   ]


### PR DESCRIPTION
The Clojure exercises are missing ratings. This isn't a great experience for users hoping to pick exercises appropriate to their level.

For a first pass at fixing this, I've copied ratings from other repos, (mainly the Elixir repo, as it's the closest language to Clojure that I can think of).

I'm sure it isn't perfect, but I think it's a decent first start, and that it's better than rating everything as 1.

Fixes https://github.com/exercism/clojure/issues/274