### PR TITLE
Add reverse-string tests

### DIFF
--- a/exercises/reverse-string/test/reverse_string_test.clj
+++ b/exercises/reverse-string/test/reverse_string_test.clj
@@ -5,6 +5,9 @@
 (deftest empty-string-test
   (is (= "" (reverse-string/reverse-string ""))))
 
+(deftest a-letter-test
+  (is (= "I" (reverse-string/reverse-string "I"))))
+
 (deftest a-word-test
   (is (= "tobor" (reverse-string/reverse-string "robot"))))
 
@@ -16,3 +19,8 @@
 
 (deftest palindrome-test
   (is (= "racecar" (reverse-string/reverse-string "racecar"))))
+
+(deftest long-string-test
+  (let [s (reduce str (repeat 1000 "overflow?"))
+        rs (reduce str (repeat 1000 "?wolfrevo"))]
+    (is (= rs (reverse-string/reverse-string s)))))


### PR DESCRIPTION
- single letter word test
- very long string test to encourage `reduce`, since a non-TCO recursive call will stack overflow.