### PR TITLE
Reorder "Armstrong numbers" to be later in the queue

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,16 +13,6 @@
       "topics": null
     },
     {
-      "slug": "armstrong-numbers",
-      "uuid": "a4bdbdfd-1db1-425c-a243-dd032dc7b93a",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "math"
-      ]
-    },
-    {
       "slug": "two-fer",
       "uuid": "91a1f32c-0dac-4c65-8a13-49da90d21520",
       "core": false,
@@ -45,6 +35,16 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": null
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "a4bdbdfd-1db1-425c-a243-dd032dc7b93a",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "rna-transcription",


### PR DESCRIPTION

Personally, I think that "armstrong numbers" is quite a difficult problem to be the very first one after "hello world"!

The first "real" problem in most other language tracks is "two-fer", and this seems about the right difficulty to me. 

I personally think the "reverse-string" and "bob" questions are a bit easier than "Armstrong numbers" as well which is why I have moved it down three spots below these three mentioned exercises. 

Go Clojureeeeeeeeeee! ❤️ 🔥 👍