### PR TITLE
add docstrings for exercises A-E

### DIFF
--- a/exercises/accumulate/src/accumulate.clj
+++ b/exercises/accumulate/src/accumulate.clj
@@ -1,5 +1,10 @@
 (ns accumulate)
 
-(defn accumulate [] ;; <- arglist goes here
-      ;; your code goes here
+(defn accumulate
+    "Given a coll and a function to perform
+   on each element of the coll, returns a new
+   coll containing the result of applying f
+   to each element of the input coll."
+  []
+      ;; function body
 )

--- a/exercises/accumulate/src/example.clj
+++ b/exercises/accumulate/src/example.clj
@@ -1,6 +1,11 @@
 (ns accumulate)
 
-(defn accumulate [f xs]
+(defn accumulate
+  "Given a coll and a function to perform
+   on each element of the coll, returns a new
+   coll containing the result of applying f
+   to each element of the input coll."
+  [f xs]
   (loop [xs xs
          accum []]
     (if

--- a/exercises/acronym/src/acronym.clj
+++ b/exercises/acronym/src/acronym.clj
@@ -1,5 +1,7 @@
 (ns acronym)
 
-(defn acronym [] ;; <- arglist goes here
-  ;; your code goes here
+(defn acronym
+    "Converts a phrase to its acronym."
+  [text]
+  ;; function body
 )

--- a/exercises/acronym/src/example.clj
+++ b/exercises/acronym/src/example.clj
@@ -1,7 +1,9 @@
 (ns acronym
   (:require [clojure.string :as str]))
 
-(defn acronym [text]
+(defn acronym
+  "Converts a phrase to its acronym."
+  [text]
   (->> (re-seq #"[A-Z]+[a-z]*|[a-z]+" text)
        (map first)
        (apply str)

--- a/exercises/all-your-base/src/all_your_base.clj
+++ b/exercises/all-your-base/src/all_your_base.clj
@@ -1,5 +1,8 @@
 (ns all-your-base)
 
-(defn convert [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn convert
+  "Converts a sequence of digits given in input-base
+   into a sequence of digits in the desired output-base."
+  [input-base digits output-base]
+  ;; function body
+  )

--- a/exercises/all-your-base/src/example.clj
+++ b/exercises/all-your-base/src/example.clj
@@ -19,7 +19,8 @@
       (recur (conj digits (mod num output-base)) (quot num output-base)))))
 
 (defn convert
-  "Converts a sequence of digits given in input-base into a sequence of digits in the desired output-base."
+  "Converts a sequence of digits given in input-base
+   into a sequence of digits in the desired output-base."
   [input-base digits output-base]
   (cond
     (some #(< % 2) (list input-base output-base)) nil

--- a/exercises/allergies/src/allergies.clj
+++ b/exercises/allergies/src/allergies.clj
@@ -1,9 +1,12 @@
 (ns allergies)
 
-(defn allergies [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn allergies
+  "Given an 8-bit bitmap of flags, returns the list of matching allergens."
+  [flags]
+  )
 
-(defn allergic-to? [] ;; <- arglist goes here
-  ;; your code goes here
+(defn allergic-to?
+  "Given an 8-bit bitmap of flags and an allergen, returns a boolean
+  indicating whether or not the patient is allergic to the given allergen."
+  [flags alergen]
 )

--- a/exercises/allergies/src/example.clj
+++ b/exercises/allergies/src/example.clj
@@ -10,7 +10,7 @@
       (pos?)))
 
 (defn allergies
-  "Given an 8-bit bitmap of flags, return the list of matching allergens."
+  "Given an 8-bit bitmap of flags, returns the list of matching allergens."
   [flags]
   (keep-indexed (fn [index allergen]
                   (when (flagged? flags index)
@@ -18,7 +18,7 @@
                 allergens))
 
 (defn allergic-to?
-  "Given an 8-bit bitmap of flags and an allergen, return a boolean
+  "Given an 8-bit bitmap of flags and an allergen, returns a boolean
   indicating whether or not the patient is allergic to the given allergen."
   [flags allergen]
   (some #{allergen} (allergies flags)))

--- a/exercises/anagram/src/anagram.clj
+++ b/exercises/anagram/src/anagram.clj
@@ -1,5 +1,6 @@
 (ns anagram)
 
-(defn anagrams-for [word prospect-list] ;; <- arglist goes here
-  ;; your code goes here
+(defn anagrams-for
+  "Returns the sublist of valid anagrams of a word from a list of words."
+  [word prospect-list]
 )

--- a/exercises/armstrong-numbers/src/armstrong_numbers.clj
+++ b/exercises/armstrong-numbers/src/armstrong_numbers.clj
@@ -1,5 +1,7 @@
 (ns armstrong-numbers)
 
-(defn armstrong? [num] ;; <- arglist goes here
-  ;; your code goes here
+(defn armstrong?
+  "Returns true if a number is an Armstrong number."
+  [num]
+  ;; function body
 )

--- a/exercises/atbash-cipher/src/atbash_cipher.clj
+++ b/exercises/atbash-cipher/src/atbash_cipher.clj
@@ -1,5 +1,6 @@
 (ns atbash-cipher)
 
-(defn encode [] ;; <- arglist goes here
-  ;; your code goes here
+(defn encode
+  "Converts plain text into Atbash cipher text."
+  [plain-text]
 )

--- a/exercises/bank-account/src/bank_account.clj
+++ b/exercises/bank-account/src/bank_account.clj
@@ -1,17 +1,21 @@
 (ns bank-account)
 
-(defn open-account [] ;; <- arglist goes here
-  ;; your code goes here
+(defn open-account
+  "Creates a new account with a balance of 0."
+  []
 )
 
-(defn close-account [] ;; <- arglist goes here
-  ;; your code goes here
+(defn close-account
+  "Sets an existing account's value to nil."
+  [account]
 )
 
-(defn get-balance [] ;; <- arglist goes here
-  ;; your code goes here
+(defn get-balance
+  "Returns a bank account's current balance."
+  [account]
 )
 
-(defn update-balance [] ;; <- arglist goes here
-  ;; your code goes here
+(defn update-balance
+  "Updates an account's balance by a positive or negative amount."
+  [account amt]
 )

--- a/exercises/beer-song/src/beer_song.clj
+++ b/exercises/beer-song/src/beer_song.clj
@@ -3,15 +3,15 @@
 (defn verse
   "Returns the nth verse of the song."
   [num]
-  ; function body
+  ; add function body
   )
 
 (defn sing
   "Given a start and an optional end, returns all verses in this interval.
    If end is not given, the whole song from start is sung."
   ([start]
-   ; single-arity
+   ; add single-arity body
    )
   ([start end]
-   ; 2-arity
+   ; add 2-arity body
    ))

--- a/exercises/beer-song/src/beer_song.clj
+++ b/exercises/beer-song/src/beer_song.clj
@@ -2,10 +2,16 @@
 
 (defn verse
   "Returns the nth verse of the song."
-  [num])
+  [num]
+  ; function body
+  )
 
 (defn sing
-  "Given a start and an optional end, returns all verses in this interval. If
-  end is not given, the whole song from start is sung."
-  ([start])
-  ([start end]))
+  "Given a start and an optional end, returns all verses in this interval.
+   If end is not given, the whole song from start is sung."
+  ([start]
+   ; single-arity
+   )
+  ([start end]
+   ; 2-arity
+   ))

--- a/exercises/binary-search-tree/src/binary_search_tree.clj
+++ b/exercises/binary-search-tree/src/binary_search_tree.clj
@@ -1,29 +1,38 @@
 (ns binary-search-tree)
 
-(defn value [] ;; <- arglist goes here
-  ;; your code goes here
+(defn value
+  "Returns the value of a node in a binary search tree."
+  [node]
 )
 
-(defn singleton [] ;; <- arglist goes here
-  ;; your code goes here
+(defn singleton
+  "Returns a node consisting of a single value."
+  [n]
 )
 
-(defn insert [] ;; <- arglist goes here
-  ;; your code goes here
+(defn left
+  "Returns the value of the left child of a node in a binary search tree."
+  [node]
+  )
+
+(defn right
+  "Returns the value of the right child of a node in a binary search tree."
+  [node]
+  )
+
+(defn insert
+  "Inserts a value into a node in a binary search tree."
+  [v node]
 )
 
-(defn left [] ;; <- arglist goes here
-  ;; your code goes here
+(defn from-list
+  "Creates a binary search tree from a list of values."
+  [xs]
+  )
+
+(defn to-list
+  "Takes a node of a binary search tree and returns a sorted list of values."
+  [node]
 )
 
-(defn right [] ;; <- arglist goes here
-  ;; your code goes here
-)
 
-(defn to-list [] ;; <- arglist goes here
-  ;; your code goes here
-)
-
-(defn from-list [] ;; <- arglist goes here
-  ;; your code goes here
-)

--- a/exercises/binary-search-tree/src/example.clj
+++ b/exercises/binary-search-tree/src/example.clj
@@ -15,8 +15,14 @@
         [x (insert v (left node)) (right node)]
         [x (left node) (insert v (right node))]))))
 
-(defn from-list [xs]
+(defn from-list
+  "Creates a binary search tree from a list of values."
+  [xs]
   (reduce #(insert %2 %1) nil xs))
+
+(comment
+  (from-list [4 2 6 1 3 7 5])
+  )
 
 (defn to-list [node]
   (if

--- a/exercises/binary-search/src/binary_search.clj
+++ b/exercises/binary-search/src/binary_search.clj
@@ -1,9 +1,11 @@
 (ns binary-search)
 
-(defn search-for [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn middle
+  "Finds the position of the middle item in a list."
+  [list]
+  )
 
-(defn middle [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn search-for
+  "Finds an element in a list by binary search."
+  [elem list]
+  )

--- a/exercises/binary/src/binary.clj
+++ b/exercises/binary/src/binary.clj
@@ -1,5 +1,5 @@
 (ns binary)
 
-(defn to-decimal [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn to-decimal
+  "Converts a binary string to decimal."
+  [s])

--- a/exercises/binary/src/example.clj
+++ b/exercises/binary/src/example.clj
@@ -18,7 +18,9 @@
        reverse
        (map-indexed vector)))
 
-(defn to-decimal [string]
+(defn to-decimal
+  "Converts a binary string to decimal."
+  [string]
   (->> string
        bits
        (map power)

--- a/exercises/bob/src/bob.clj
+++ b/exercises/bob/src/bob.clj
@@ -1,5 +1,7 @@
 (ns bob)
 
-(defn response-for [s] ;; <- arglist goes here
-  ;; your code goes here
+(defn response-for
+  "Returns Bob's appropriate lackadaisical response for an input string."
+  [s]
+  ; function body
 )

--- a/exercises/change/src/change.clj
+++ b/exercises/change/src/change.clj
@@ -1,5 +1,6 @@
 (ns change)
 
-(defn issue [] ;; <- arglist goes here
-  ;; your code goes here
+(defn issue
+  "Outputs the fewest number of coins that add up to a given sum."
+  [sum coins]
 )

--- a/exercises/change/src/example.clj
+++ b/exercises/change/src/example.clj
@@ -1,6 +1,8 @@
 (ns change)
 
-(defn issue [sum coins]
+(defn issue
+  "Outputs the fewest number of coins that add up to a given sum."
+  [sum coins]
   (when (or (neg? sum) (and (pos? sum) (every? #(< sum %) coins)))
     (throw (IllegalArgumentException. "cannot change")))
   (let [coins (sort coins)

--- a/exercises/clock/src/clock.clj
+++ b/exercises/clock/src/clock.clj
@@ -1,13 +1,16 @@
 (ns clock)
 
-(defn clock->string [clock] ;; <- arglist goes here
-  ;; your code goes here
+(defn clock->string
+  "Prints the HH:MM representation of a clock."
+  [clock]
 )
 
-(defn clock [hours minutes] ;; <- arglist goes here
-  ;; your code goes here
+(defn clock
+  "Returns a 24 hour clock representation of the given hours and minutes."
+  [hours minutes]
 )
 
-(defn add-time [clock time] ;; <- arglist goes here
-  ;; your code goes here
+(defn add-time
+  "Adds minutes to the given clock."
+  [clock minutes]
 )

--- a/exercises/clock/src/example.clj
+++ b/exercises/clock/src/example.clj
@@ -15,5 +15,5 @@
 
 (defn add-time
   "Adds minutes to the given clock."
-  [clock minutes]
-  (clock (:hour clock) (+ (:minute clock) minutes)))
+  [in-clock minutes]
+  (clock (:hour in-clock) (+ (:minute in-clock) minutes)))

--- a/exercises/clock/src/example.clj
+++ b/exercises/clock/src/example.clj
@@ -1,7 +1,7 @@
 (ns clock)
 
 (defn clock
-  "Return a 24 hour clock representation of the given hours and minutes."
+  "Returns a 24 hour clock representation of the given hours and minutes."
   [in-hour in-minute]
   (let [total-minutes (mod (+ (* in-hour 60) in-minute) (* 60 24))
         hours (mod (quot total-minutes 60) 24)
@@ -9,11 +9,11 @@
     {:hour hours :minute minutes}))
 
 (defn clock->string
-  "Print the HH:MM representation of a clock."
+  "Prints the HH:MM representation of a clock."
   [in-clock]
   (format "%02d:%02d" (:hour in-clock) (:minute in-clock)))
 
 (defn add-time
-  "Add minutes to the given clock."
-  [in-clock minutes-to-add]
-  (clock (:hour in-clock) (+ (:minute in-clock) minutes-to-add)))
+  "Adds minutes to the given clock."
+  [clock minutes]
+  (clock (:hour clock) (+ (:minute clock) minutes)))

--- a/exercises/collatz-conjecture/src/collatz_conjecture.clj
+++ b/exercises/collatz-conjecture/src/collatz_conjecture.clj
@@ -1,5 +1,6 @@
 (ns collatz-conjecture)
 
-(defn collatz [num] ;; <- arglist goes here
-  ;; your code goes here
+(defn collatz
+  "Returns the total number of steps in a number's Collatz sequence."
+  [num]
 )

--- a/exercises/complex-numbers/src/complex_numbers.clj
+++ b/exercises/complex-numbers/src/complex_numbers.clj
@@ -1,33 +1,41 @@
 (ns complex-numbers)
 
-(defn real [[a b]] ;; <- arglist goes here
-  ;; your code goes here
+(defn real
+  "Returns the real part of a complex number."
+  [[real _]]
 )
 
-(defn imaginary [[a b]] ;; <- arglist goes here
-  ;; your code goes here
+(defn imaginary
+  "Returns the imaginary part of a complex number."
+  [[_ imag]]
+  )
+
+(defn abs
+  "Returns the absolute value of a complex number."
+  [[real imag]]
 )
 
-(defn abs [[a b]] ;; <- arglist goes here
-  ;; your code goes here
+(defn conjugate
+  "Returns the conjugate of a complex number."
+  [[real imag]]
 )
 
-(defn conjugate [[a b]] ;; <- arglist goes here
-  ;; your code goes here
+(defn add
+  "Returns the sum of 2 complex numbers."
+  [[real imag] [real imag]]
 )
 
-(defn add [[a b] [c d]] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn sub
+  "Returns the difference of 2 complex numbers."
+  [[real imag] [real imag]]
+  )
 
-(defn sub [[a b] [c d]] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn mul
+  "Returns the result of multiplying 2 complex numbers."
+  [[real imag] [real imag]]
+  )
 
-(defn mul [[a b] [c d]] ;; <- arglist goes here
-  ;; your code goes here
-)
-
-(defn div [[a b] [c d]] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn div
+  "Returns the result of dividing 2 complex numbers."
+  [[real imag] [real imag]]
+  )

--- a/exercises/crypto-square/src/crypto_square.clj
+++ b/exercises/crypto-square/src/crypto_square.clj
@@ -1,21 +1,26 @@
 (ns crypto-square)
 
-(defn normalize-plaintext [] ;; <- arglist goes here
-  ;; your code goes here
+(defn normalize-plaintext
+  "Returns an input string with spaces and punctuation removed."
+  [s]
 )
 
-(defn square-size [] ;; <- arglist goes here
-  ;; your code goes here
+(defn square-size
+  "Calculates the size of an input string's crypto-square."
+  [s]
 )
 
-(defn plaintext-segments [] ;; <- arglist goes here
-  ;; your code goes here
+(defn plaintext-segments
+  "Breaks a plaintext string into segments of proper size."
+  [s]
 )
 
-(defn ciphertext [] ;; <- arglist goes here
-  ;; your code goes here
+(defn ciphertext
+  "Converts a plaintext input string into square-code ciphertext."
+  [s]
 )
 
-(defn normalize-ciphertext [] ;; <- arglist goes here
-  ;; your code goes here
+(defn normalize-ciphertext
+  "Prints a string of ciphertext arranged into a square."
+  [s]
 )

--- a/exercises/diamond/src/diamond.clj
+++ b/exercises/diamond/src/diamond.clj
@@ -1,5 +1,7 @@
 (ns diamond)
 
-(defn diamond [] ;; <- arglist goes here
-  ;; your code goes here
+(defn diamond
+  "Takes a character as input, and prints a diamond-shaped pattern
+   with the supplied character at its widest point."
+  [c]
 )

--- a/exercises/difference-of-squares/src/difference_of_squares.clj
+++ b/exercises/difference-of-squares/src/difference_of_squares.clj
@@ -1,13 +1,17 @@
 (ns difference-of-squares)
 
-(defn difference [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn sum-of-squares
+  "Finds the sum of the squares of the first n natural numbers."
+  [n]
+  )
 
-(defn sum-of-squares [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn square-of-sum
+  "Finds the square of the sum of the first n natural numbers."
+  [n]
+  )
 
-(defn square-of-sum [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn difference
+  "Finds the difference between the square of the sum
+   and the sum of the squares of the first n natural numbers."
+  [n]
+  )

--- a/exercises/dominoes/src/dominoes.clj
+++ b/exercises/dominoes/src/dominoes.clj
@@ -1,5 +1,6 @@
 (ns dominoes)
 
-(defn can-chain? [] ;; <- arglist goes here
-  ;; your code goes here
+(defn can-chain?
+  "Returns true if a sequence of dominoes can be chained."
+  [xs]
 )

--- a/exercises/dominoes/src/example.clj
+++ b/exercises/dominoes/src/example.clj
@@ -4,17 +4,21 @@
   (let [i (.indexOf xs x)]
     (if (= -1 i) xs (vec (concat (take i xs) (drop (inc i) xs))))))
 
-(defn connects [[a b] [c d]]
+(defn connects [[_ b] [c d]]
   (cond (= b c) [c d]
         (= b d) [d c]
         :else   nil))
 
 (defn backtrack [rem chain]
   (or (and (empty? rem) (= (ffirst chain) (second (peek chain))))
-      (and (not (empty? rem))
+      (and (seq rem)
            (some #(let [c (connects (peek chain) %)]
                     (and c (backtrack (rm rem %) (conj chain c))))
                  rem))))
 
 (defn can-chain? [xs]
   (or (empty? xs) (some #(backtrack (rm xs %) [%]) xs)))
+
+(comment
+  (can-chain?  [[1 2] [3 1] [2 3]])
+  )

--- a/exercises/etl/src/etl.clj
+++ b/exercises/etl/src/etl.clj
@@ -1,5 +1,7 @@
 (ns etl)
 
-(defn transform [source] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn transform
+  "Accepts a map of scores to strings,
+   and returns a map of each letter to its score."
+  [legacy-data]
+  )

--- a/exercises/etl/src/example.clj
+++ b/exercises/etl/src/example.clj
@@ -1,8 +1,11 @@
 (ns etl
   (:require [clojure.string :refer [lower-case]]))
 
-(defn transform [extract]
+(defn transform
+  "Accepts a map of scores to strings,
+   and returns a map of each letter to its score."
+  [legacy-data]
   (into {}
-        (for [[score letters] extract
+        (for [[score letters] legacy-data
               letter          letters]
           [(lower-case letter) score])))


### PR DESCRIPTION
Bringing exercises up to date with our current working style-guide, which I've taken as far as providing docstrings for the function stubs.

It seems to me that they are very helpful and would expect students to appreciate them. Plus they are fun to write and I've been learning a lot by doing it. Which actually gives me some second thoughts -

Am I robbing the student of the experience of learning to write effective docstrings by doing this work for them? The main purpose was to encourage their use, but this could also be accomplished with a generic placeholder.

Feedback appreciated!