### PR TITLE
Fixing phone-number test cases

### DIFF
--- a/exercises/phone-number/src/example.clj
+++ b/exercises/phone-number/src/example.clj
@@ -7,7 +7,7 @@
 
 (defn- extract-parts
   [input]
-  (if-let [matches (re-find #"^1?(...)(...)(....)$" input)]
+  (if-let [matches (re-find #"^1?([2-9]..)([2-9]..)(....)$" input)]
     (rest matches)
     ["000" "000" "0000"]))
 

--- a/exercises/phone-number/test/phone_number_test.clj
+++ b/exercises/phone-number/test/phone_number_test.clj
@@ -3,7 +3,7 @@
             phone-number))
 
 (deftest cleans-number
-  (is (= "1234567890" (phone-number/number "(123) 456-7890"))))
+  (is (= "2234567890" (phone-number/number "(223) 456-7890"))))
 
 (deftest cleans-number-with-dots
   (is (= "5558675309" (phone-number/number "555.867.5309"))))
@@ -11,14 +11,32 @@
 (deftest valid-when-11-digits-and-first-is-1
   (is (= "9876543210" (phone-number/number "19876543210"))))
 
+(deftest invalid-when-area-code-starts-with-0
+  (is (= "0000000000" (phone-number/number "0234567890"))))
+
+(deftest invalid-when-area-code-starts-with-1
+  (is (= "0000000000" (phone-number/number "1234567890"))))
+
+(deftest invalid-when--code-starts-with-0
+  (is (= "0000000000" (phone-number/number "0234567890"))))
+
+(deftest invalid-when-exchange-code-starts-with-1
+  (is (= "0000000000" (phone-number/number "2231567890"))))
+
+(deftest invalid-when-exchange-code-starts-with-0
+  (is (= "0000000000" (phone-number/number "2230567890"))))
+
+(deftest invalid-when-area-code-starts-with-1
+  (is (= "0000000000" (phone-number/number "1234567890"))))
+
 (deftest invalid-when-11-digits
-  (is (= "0000000000" (phone-number/number "21234567890"))))
+  (is (= "0000000000" (phone-number/number "22234567890"))))
 
 (deftest invalid-when-9-digits
   (is (= "0000000000" (phone-number/number "123456789"))))
 
 (deftest area-code
-  (is (= "123" (phone-number/area-code "1234567890"))))
+  (is (= "223" (phone-number/area-code "2234567890"))))
 
 (deftest area-code-with-dots
   (is (= "555" (phone-number/area-code "555.867.5309"))))
@@ -27,10 +45,10 @@
   (is (= "987" (phone-number/area-code "(987) 654-3210"))))
 
 (deftest area-code-with-full-us-phone-number
-  (is (= "123" (phone-number/area-code "11234567890"))))
+  (is (= "223" (phone-number/area-code "12234567890"))))
 
 (deftest pretty-print
-  (is (= "(123) 456-7890" (phone-number/pretty-print "1234567890"))))
+  (is (= "(223) 456-7890" (phone-number/pretty-print "2234567890"))))
 
 (deftest pretty-print-with-dots
   (is (= "(555) 867-5309" (phone-number/pretty-print "555.867.5309"))))


### PR DESCRIPTION
README for the phone-number exercise specifies certain phone number digits as being 2-9, but the tests allow and use 0-9 for these digits.

Perhaps validating these digits conform is out of scope for these tests, but the tests are also written so that people who want to add these validations actually fail the tests.