### PR TITLE
remove use of 'and' in say description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pom.xml.asc
 *.nrepl-port
 .clj-kondo
 .lsp
+*.calva

--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -58,6 +58,6 @@ Use _and_ (correctly) when spelling out the number in English:
 
 - 14 becomes "fourteen".
 - 100 becomes "one hundred".
-- 120 becomes "one hundred and twenty".
-- 1002 becomes "one thousand and two".
-- 1323 becomes "one thousand three hundred and twenty-three".
+- 120 becomes "one hundred twenty".
+- 1002 becomes "one thousand two".
+- 1323 becomes "one thousand three hundred twenty-three".

--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -51,13 +51,3 @@ Put it all together to get nothing but plain English.
 `12345` should give `twelve thousand three hundred forty-five`.
 
 The program must also report any values that are out of range.
-
-### Extensions
-
-Use _and_ (correctly) when spelling out the number in English:
-
-- 14 becomes "fourteen".
-- 100 becomes "one hundred".
-- 120 becomes "one hundred twenty".
-- 1002 becomes "one thousand two".
-- 1323 becomes "one thousand three hundred twenty-three".


### PR DESCRIPTION
Fixes #302.

I went ahead and just removed the Extensions section completely, since "and" is _never_ actually used. Therefore it was serving no purpose other than confusing people IMO.

EDIT: It turns out it went completely over my head. "Extensions" is only meant to be a suggested exercise for the student, i.e. to further refine the program to use "and" as it is often used in English ("Three hundred **and** four", etc.). I still personally think we should take it out because it's mildly helpful at best. The exercise is plenty complicated as it is.