### PR TITLE
🤖 Add blurb to .meta/config.json files

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,14 +1,19 @@
 {
+  "blurb": "TODO: add blurb for annalyns-infiltration exercise",
   "authors": [
     {
       "github_username": "porkostomus",
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/booleans"],
+  "forked_from": [
+    "fsharp/booleans"
+  ],
   "files": {
     "solution": [],
     "test": [],
-    "exemplar": [".meta/exemplar.clj"]
+    "exemplar": [
+      ".meta/exemplar.clj"
+    ]
   }
 }

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -1,11 +1,14 @@
 {
+  "blurb": "TODO: add blurb for bird-watcher exercise",
   "authors": [
     {
       "github_username": "porkostomus",
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["csharp/arrays"],
+  "forked_from": [
+    "csharp/arrays"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -1,14 +1,19 @@
 {
+  "blurb": "TODO: add blurb for cars-assemble exercise",
   "authors": [
     {
       "github_username": "porkostomus",
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/numbers"],
+  "forked_from": [
+    "fsharp/numbers"
+  ],
   "files": {
     "solution": [],
     "test": [],
-    "exemplar": [".meta/exemplar.clj"]
+    "exemplar": [
+      ".meta/exemplar.clj"
+    ]
   }
 }

--- a/exercises/concept/log-levels/.meta/config.json
+++ b/exercises/concept/log-levels/.meta/config.json
@@ -1,14 +1,19 @@
 {
+  "blurb": "TODO: add blurb for log-levels exercise",
   "authors": [
     {
       "github_username": "porkostomus",
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/strings"],
+  "forked_from": [
+    "fsharp/strings"
+  ],
   "files": {
     "solution": [],
     "test": [],
-    "exemplar": [".meta/exemplar.clj"]
+    "exemplar": [
+      ".meta/exemplar.clj"
+    ]
   }
 }

--- a/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -1,14 +1,19 @@
 {
+  "blurb": "TODO: add blurb for lucians-luscious-lasagna exercise",
   "authors": [
     {
       "github_username": "porkostomus",
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/basics"],
+  "forked_from": [
+    "fsharp/basics"
+  ],
   "files": {
     "solution": [],
     "test": [],
-    "exemplar": [".meta/exemplar.clj"]
+    "exemplar": [
+      ".meta/exemplar.clj"
+    ]
   }
 }

--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for tracks-on-tracks-on-tracks exercise",
   "contributors": [
     {
       "github_username": "bemself",
@@ -12,6 +13,8 @@
   "files": {
     "solution": [],
     "test": [],
-    "exemplar": [".meta/exemplar.clj"]
+    "exemplar": [
+      ".meta/exemplar.clj"
+    ]
   }
 }

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a long phrase to its acronym",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a number is an Armstrong number",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Insert and search for numbers in a binary tree.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement a binary search algorithm.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Correctly determine change to be given using the least number of coins",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement a clock that handles times without dates.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement complex numbers.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Make a chain of dominoes.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Take a nested list and return a single list with all values except nil/null",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Count the scored points on a Go board.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Check if a given string is a valid ISBN-10 number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Make sure the brackets and braces all match.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the date of meetups.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Add the numbers to a minesweeper board",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a number n, determine what the nth prime is.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement a program that translates from English to Pig Latin",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Pick the best hand(s) from a list of poker hands.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/pov/.meta/config.json
+++ b/exercises/practice/pov/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Reparent a graph on a selected node",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Compute the prime factors of a given natural number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Translate RNA sequences into proteins.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Reverse a string",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Manage robot factory settings.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Write a robot simulator.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement run-length encoding and decoding.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Write a function to determine if a list is a sublist of another list.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "authors": [],
   "files": {
     "solution": [],


### PR DESCRIPTION
Each Concept and Practice Exercise will have to define a _blurb_, which is a short description of the exercise.
The blurb will be displayed on a track's exercises page and on exercise tooltips. For example:

<img width="1194" alt="Screenshot 2021-03-02 at 13 25 38" src="https://user-images.githubusercontent.com/286476/109655154-da058500-7b5a-11eb-8346-bf733a72b3d0.png">
<img width="400" alt="Screenshot 2021-03-02 at 13 25 51" src="https://user-images.githubusercontent.com/286476/109655162-dd007580-7b5a-11eb-88f8-582532be9b84.png">

Blurbs must be limited to 350 chars and will be truncated in some views.

For Practice Exercises that are based on an exercise defined in the problem-specification repo, the blurb must match the contents of the problem-specifications exercises, which is defined in its `metadata.yml` file. In this PR, we'll do an initial syncing of the blurb. The new [configlet](https://github.com/exercism/configlet) version will add support for doing this syncing automatically.

If the Practice Exercise was _not_ based on a problems-specifications exercise, we've used the blurb from its `.meta/metadata.yml` file as the blurb in the .meta/config.json file.

For Concept Exercises, we've added a placeholder blurb to the .meta/config.json file of each Concept Exercise.

**We've opened an [issue for replacing the Concept Exercise placeholder blurbs](342) with sensible descriptions. Our recommendation is to merge this PR and then replace the placeholder blurbs in a follow-up PR. For forked exercises, it might be useful to check how other tracks have defined their blurb.**  

See the [Concept Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/concept-exercises.md#file-metaconfigjson) and [Practice Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson) for more information.

## Tracking

https://github.com/exercism/v3-launch/issues/21
