### PR TITLE
🤖 Add .meta/config.json file for concepts

### DIFF
--- a/concepts/lists/.meta/config.json
+++ b/concepts/lists/.meta/config.json
@@ -1,0 +1,8 @@
+{
+  "blurb": "TODO: add blurb for lists concept",
+  "authors": [],
+  "contributors": [
+    "bemself",
+    "cstby"
+  ]
+}

--- a/config.json
+++ b/config.json
@@ -829,8 +829,7 @@
     {
       "uuid": "33947666-6176-4ab6-825f-08b689c8040d",
       "slug": "lists",
-      "name": "Lists",
-      "blurb": "TODO: add blurb for lists concept"
+      "name": "Lists"
     }
   ],
   "key_features": [],


### PR DESCRIPTION
_TL;DR; Add authors/contributors to a new `concepts/<slug>/.meta/config.json` to Concepts in the same way you have for Concept Exercises._

---

To properly attribute authorship/contributorship for an individual concept, each concept will have its own `.meta/config.json` file with `authors` and `contributors` keys like those for concept and practice exercises. We're also moving the concept's blurb from the track's `config.json` to the `.meta/config.json` file, also similar to concept and practice exercises.

See https://github.com/exercism/docs/pull/96/files for the update to the specification.

This PR adds a `.meta/config.json` file for all concepts found in the track's `config.json` file containing:

- A `blurb` key, which value is copied from the `config.json` file and subsequently removed from the `config.json` file
- An `authors` key, the value of which is copied from the exercise teaching the concept (if any)
- A `contributors` key, the value of which is copied from the exercise teaching the concept (if any)

**For ease, the concept's authors/contributors are pre-populated with the authors/contributors of the exercise that teaches the concept (if any).**

## Maintainers TODO list

These are the things you, the maintainers, should do:

- [ ] Update the authors (if needed) 
- [ ] Update the contributors (if needed)

**For clarity, authors should be the people who originally created the concept documents on this track. Contributors should be people who have substantially contributed to the concept documents. PRs for typos or multiple-concept PRs do not automatically mean someone should be considered a contributor to that concept. Those non-concept-specific contributions will get recognition through Exercism's reputation system in v3.**

You can either update this PR by pushing a new commit to this PR, or merge this and do a follow-up PR later. The former has the disadvantage that once we've added linting rules to `configlet` for the concept `.meta/config.json` file, the configlet CI check will start failing. 

## Tracking

https://github.com/exercism/v3-launch/issues/27
