### PR TITLE
🤖 Remove `online_editor.ace_editor_language` key

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,6 @@
   "online_editor": {
     "indent_style": "space",
     "indent_size": 2,
-    "ace_editor_language": "clojure",
     "highlightjs_language": "clojure"
   },
   "test_runner": {


### PR DESCRIPTION
We've recently switched from Ace to CodeMirror as our editor. This PR removes the now obsolete `.online_editor.ace_editor_language` key.

## Tracking

https://github.com/exercism/v3-launch/issues/40