### PR TITLE
Add two more diagonal test cases for queen attack

### DIFF
--- a/exercises/practice/queen-attack/test/queen_attack_test.clj
+++ b/exercises/practice/queen-attack/test/queen_attack_test.clj
@@ -33,4 +33,6 @@
   (is (= true  (queen-attack/can-attack {:w [5 4] :b [2 4]})))
   (is (= true  (queen-attack/can-attack {:w [1 1] :b [6 6]})))
   (is (= true  (queen-attack/can-attack {:w [0 6] :b [1 7]})))
-  (is (= true  (queen-attack/can-attack {:w [4 1] :b [6 3]}))))
+  (is (= true  (queen-attack/can-attack {:w [4 1] :b [6 3]})))
+  (is (= true  (queen-attack/can-attack {:w [2 3] :b [5 0]})))
+  (is (= true  (queen-attack/can-attack {:w [2 3] :b [0 5]}))))


### PR DESCRIPTION
The current diagonal tests take place in a situation where the white piece is "to the left and above" the black piece, which means that a technically invalid solution, which does not properly consider all diagonal attack vectors, may pass all test cases.

Given the current test cases:

```clojure
  (is (= true  (queen-attack/can-attack {:w [1 1] :b [6 6]})))
  (is (= true  (queen-attack/can-attack {:w [0 6] :b [1 7]})))
  (is (= true  (queen-attack/can-attack {:w [4 1] :b [6 3]})))
```

If we decompose `w` and `b` as `{[x1 y1] :w, [x2 y2] :b}`, then:

```
x1 <= x2
y1 <= y2
```

This commit adds two more valid diagonal test cases:

```clojure
  (is (= true  (queen-attack/can-attack {:w [2 3] :b [5 0]})))
  (is (= true  (queen-attack/can-attack {:w [2 3] :b [0 5]}))))
```

These will fail certain implementations which would pass the previous test suite, such as:

```clojure
(= (- y2 y1) (- x2 x1))
```

Or:

```clojure
(= (- x1 y1) (- x2 y2))
```