### PR TITLE
Fix lint and lein test commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ lein: lein
 jdk: openjdk8
 script:
 - bin/fetch-configlet
-- bin/configlet lint .
+- bin/configlet lint
 - lein test

--- a/_test/check_exercises.clj
+++ b/_test/check_exercises.clj
@@ -5,10 +5,10 @@
 
 (defn- ->snake_case [s] (string/replace s \- \_))
 
-(deftest check-exercises
-  (doseq [exercise ((json/parse-string (slurp "config.json")) "exercises")
+(deftest check-practice-exercises
+  (doseq [exercise (((json/parse-string (slurp "config.json")) "exercises") "practice")
           :let [slug             (exercise "slug")
-                path-to-exercise (partial str "exercises/" slug "/")
+                path-to-exercise (partial str "exercises/practice/" slug "/")
                 exercise-tests   (symbol (str slug "-test"))]]
     (load-file (path-to-exercise "src/example.clj"))
     (load-file (path-to-exercise "test/" (->snake_case slug) "_test.clj"))


### PR DESCRIPTION
Lint and lein test commands are failing on TraviCI. Fix them:

* Remove the unnecessary directory argument `.` to the `bin/configlet lint` command. Now it stills fails, but because the linter fails, not because the command is being called incorrectly. I decide to not fix the lint itself now since that'd require updating a lot of descriptions and which I have little knowledge or context of.

* Update `check-exercises` test, replacing it by `check-practice-exercises`. It was failing with `java.lang.IllegalArgumentException: Key must be integer` (see https://travis-ci.org/github/exercism/clojure/builds/774449427). Now it tests only practice tests, within the `/exercies/practice/` folder. Note that I tried to add a test for concept exercises as well but they do not use `lein` and I could not get the `load-file` to work properly.