### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -854,32 +854,32 @@
     {
       "title": "Lisp",
       "content": "Extends Lisp's code-as-data system to vectors and maps, and has a powerful macro system.",
-      "icon": "features-lisp"
+      "icon": "multi-paradigm"
     },
     {
       "title": "Dynamic",
       "content": "Clojure's primary programming interface is the Read-Eval-Print-Loop (REPL).",
-      "icon": "features-dynamic"
+      "icon": "interactive"
     },
     {
       "title": "Functional",
       "content": "Allows avoiding mutable state, provides functions as first-class objects, and emphasizes recursion.",
-      "icon": "features-functional"
+      "icon": "functional"
     },
     {
       "title": "Practical",
       "content": "Doesn’t force programs to be referentially transparent, and doesn’t strive for 'provable' programs.",
-      "icon": "features-practical"
+      "icon": "productive"
     },
     {
       "title": "Concurrent",
       "content": "Supports sharing changing state between threads in a synchronous and coordinated manner.",
-      "icon": "features-concurrent"
+      "icon": "concurrency"
     },
     {
       "title": "JVM Hosted",
       "content": "Shares the JVM type system, GC, threads etc. Compiles all functions to JVM bytecode.",
-      "icon": "features-jvm"
+      "icon": "stable"
     }
   ],
   "tags": [


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![multi-paradigm](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/multi-paradigm.svg) Lisp
Extends Lisp's code-as-data system to vectors and maps, and has a powerful macro system.

![interactive](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interactive.svg) Dynamic
Clojure's primary programming interface is the Read-Eval-Print-Loop (REPL).

![functional](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/functional.svg) Functional
Allows avoiding mutable state, provides functions as first-class objects, and emphasizes recursion.

![productive](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/productive.svg) Practical
Doesn’t force programs to be referentially transparent, and doesn’t strive for 'provable' programs.

![concurrency](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/concurrency.svg) Concurrent
Supports sharing changing state between threads in a synchronous and coordinated manner.

![stable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/stable.svg) JVM Hosted
Shares the JVM type system, GC, threads etc. Compiles all functions to JVM bytecode.
