### PR TITLE
Update average test runner time

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "highlightjs_language": "clojure"
   },
   "test_runner": {
-    "average_run_time": 4.0
+    "average_run_time": 1.0
   },
   "files": {
     "solution": [


### PR DESCRIPTION
With the updated version of the test runner that uses babashka, test runs finish in about 1 second. Quite an impressive feat!
