### PR TITLE
Fix namespaces to match directory structure

### DIFF
--- a/exercises/concept/annalyns-infiltration/src/annalyns_infiltration.clj
+++ b/exercises/concept/annalyns-infiltration/src/annalyns_infiltration.clj
@@ -1,4 +1,4 @@
-(ns exercism.quest-logic)
+(ns quest-logic)
 
 (defn can-fast-attack?
   "Returns true if a fast-attack can be made, false otherwise."

--- a/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
+++ b/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.quest-logic-test
+(ns quest-logic-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.quest-logic))
 

--- a/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
+++ b/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
@@ -1,75 +1,75 @@
 (ns quest-logic-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.quest-logic))
+            quest-logic))
 
 (deftest fast-attack-test
   (testing "Fast attack if knight is"
     (testing "awake"
-      (is (= false (exercism.quest-logic/can-fast-attack? true))))
+      (is (= false (quest-logic/can-fast-attack? true))))
     (testing "sleeping"
-      (is (= true (exercism.quest-logic/can-fast-attack? false))))))
+      (is (= true (quest-logic/can-fast-attack? false))))))
 
 (deftest spy-test
   (testing "Cannot spy if everyone is sleeping"
-    (is (= false (exercism.quest-logic/can-spy? false false false))))
+    (is (= false (quest-logic/can-spy? false false false))))
   (testing "Can spy if everyone but knight is sleeping"
-    (is (= true (exercism.quest-logic/can-spy? true false false))))
+    (is (= true (quest-logic/can-spy? true false false))))
   (testing "Can spy if everyone but archer is sleeping"
-    (is (= true (exercism.quest-logic/can-spy? false true false))))
+    (is (= true (quest-logic/can-spy? false true false))))
   (testing "Can spy if everyone but prisoner is sleeping"
-    (is (= true (exercism.quest-logic/can-spy? false false true))))
+    (is (= true (quest-logic/can-spy? false false true))))
   (testing "Can spy if only knight is sleeping"
-    (is (= true (exercism.quest-logic/can-spy? false true true))))
+    (is (= true (quest-logic/can-spy? false true true))))
   (testing "Can spy if only archer is sleeping"
-    (is (= true (exercism.quest-logic/can-spy? true false true))))
+    (is (= true (quest-logic/can-spy? true false true))))
   (testing "Can spy if only prisoner is sleeping"
-    (is (= true (exercism.quest-logic/can-spy? true true false))))
+    (is (= true (quest-logic/can-spy? true true false))))
   (testing "Can spy if everyone is awake"
-    (is (= true (exercism.quest-logic/can-spy? true true true)))))
+    (is (= true (quest-logic/can-spy? true true true)))))
 
 (deftest signal-prisoner-test
   (testing "Can signal prisoner if archer is sleeping and prisoner is awake"
-    (is (= true (exercism.quest-logic/can-signal-prisoner? false true))))
+    (is (= true (quest-logic/can-signal-prisoner? false true))))
   (testing "Cannot signal prisoner if"
     (testing "archer is awake and prisoner is sleeping"
-      (is (= false (exercism.quest-logic/can-signal-prisoner? true false))))
+      (is (= false (quest-logic/can-signal-prisoner? true false))))
     (testing "archer and prisoner are both sleeping"
-      (is (= false (exercism.quest-logic/can-signal-prisoner? false false))))
+      (is (= false (quest-logic/can-signal-prisoner? false false))))
     (testing "archer and prisoner are both awake"
-      (is (= false (exercism.quest-logic/can-signal-prisoner? true true))))))
+      (is (= false (quest-logic/can-signal-prisoner? true true))))))
 
 (deftest release-prisoner-test
   (testing "Cannot release prisoner if"
     (testing "everyone is awake and pet dog is present"
-      (is (= false (exercism.quest-logic/can-free-prisoner? true true true true))))
+      (is (= false (quest-logic/can-free-prisoner? true true true true))))
     (testing "everyone is awake and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? true true true false))))
+      (is (= false (quest-logic/can-free-prisoner? true true true false))))
     (testing "everyone is asleep and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? false false false false))))
+      (is (= false (quest-logic/can-free-prisoner? false false false false))))
     (testing "only archer is awake and pet dog is present"
-      (is (= false (exercism.quest-logic/can-free-prisoner? false true false true))))
+      (is (= false (quest-logic/can-free-prisoner? false true false true))))
     (testing "only archer is awake and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? false true false false))))
+      (is (= false (quest-logic/can-free-prisoner? false true false false))))
     (testing "only knight is awake and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? true false false false))))
+      (is (= false (quest-logic/can-free-prisoner? true false false false))))
     (testing "only knight is asleep and pet dog is present"
-      (is (= false (exercism.quest-logic/can-free-prisoner? false true true true))))
+      (is (= false (quest-logic/can-free-prisoner? false true true true))))
     (testing "only knight is asleep and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? false true true false))))
+      (is (= false (quest-logic/can-free-prisoner? false true true false))))
     (testing "only archer is asleep and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? true false true false))))
+      (is (= false (quest-logic/can-free-prisoner? true false true false))))
     (testing "only prisoner is asleep and pet dog is present"
-      (is (= false (exercism.quest-logic/can-free-prisoner? true true false true))))
+      (is (= false (quest-logic/can-free-prisoner? true true false true))))
     (testing "only prisoner is asleep and pet dog is absent"
-      (is (= false (exercism.quest-logic/can-free-prisoner? true true false false)))))
+      (is (= false (quest-logic/can-free-prisoner? true true false false)))))
   (testing "Can release prisoner if"
     (testing "everyone is asleep and pet dog is present"
-      (is (= true (exercism.quest-logic/can-free-prisoner? false false false true))))
+      (is (= true (quest-logic/can-free-prisoner? false false false true))))
     (testing "only prisoner is awake and pet dog is present"
-      (is (= true (exercism.quest-logic/can-free-prisoner? false false true true))))
+      (is (= true (quest-logic/can-free-prisoner? false false true true))))
     (testing "only prisoner is awake and pet dog is absent"
-      (is (= true (exercism.quest-logic/can-free-prisoner? false false true false))))
+      (is (= true (quest-logic/can-free-prisoner? false false true false))))
     (testing "only knight is awake and pet dog is present"
-      (is (= true (exercism.quest-logic/can-free-prisoner? true false false true))))
+      (is (= true (quest-logic/can-free-prisoner? true false false true))))
     (testing "only archer is asleep and pet dog is present"
-      (is (= true (exercism.quest-logic/can-free-prisoner? true false true true))))))
+      (is (= true (quest-logic/can-free-prisoner? true false true true))))))

--- a/exercises/concept/bird-watcher/src/bird_watcher.clj
+++ b/exercises/concept/bird-watcher/src/bird_watcher.clj
@@ -1,4 +1,4 @@
-(ns exercism.bird-count)
+(ns bird-count)
 
 (def last-week [0 2 5 3 7 8 4])
 (def birds-per-day [2 5 0 7 4 1])

--- a/exercises/concept/bird-watcher/test/bird_watcher_test.clj
+++ b/exercises/concept/bird-watcher/test/bird_watcher_test.clj
@@ -1,42 +1,42 @@
 (ns bird-count-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.bird-count))
+            bird-count))
 
 (deftest last-week-test
-  (is (= [0 2 5 3 7 8 4] exercism.bird-count/last-week)))
+  (is (= [0 2 5 3 7 8 4] bird-count/last-week)))
 
 (deftest today-test
   (testing "Today's bird count of disappointing week"
-    (is (= 0 (exercism.bird-count/today [0 0 2 0 0 1 0]))))
+    (is (= 0 (bird-count/today [0 0 2 0 0 1 0]))))
   (testing "Today's bird count of busy week"
-    (is (= 10 (exercism.bird-count/today [8 8 9 5 4 7 10])))))
+    (is (= 10 (bird-count/today [8 8 9 5 4 7 10])))))
 
 (deftest increment-bird-test
   (testing "Increment today's count with no previous visits"
-    (is (= [6 5 5 11 2 5 1] (exercism.bird-count/inc-bird [6 5 5 11 2 5 0]))))
+    (is (= [6 5 5 11 2 5 1] (bird-count/inc-bird [6 5 5 11 2 5 0]))))
   (testing "Increment today's count with multiple previous visits"
-    (is (= [5 2 4 2 4 5 8] (exercism.bird-count/inc-bird [5 2 4 2 4 5 7])))))
+    (is (= [5 2 4 2 4 5 8] (bird-count/inc-bird [5 2 4 2 4 5 7])))))
 
 (deftest day-without-birds-test
   (testing "Has day without birds with day without birds"
-    (is (= true (exercism.bird-count/day-without-birds? [5 5 4 0 7 6 7]))))
+    (is (= true (bird-count/day-without-birds? [5 5 4 0 7 6 7]))))
   (testing "Has day without birds with no day without birds"
-    (is (= false (exercism.bird-count/day-without-birds? [5 5 4 1 7 6 7])))))
+    (is (= false (bird-count/day-without-birds? [5 5 4 1 7 6 7])))))
 
 (deftest n-days-count-test
   (testing "Count for first three days of disappointing week"
-    (is (= 1 (exercism.bird-count/n-days-count [0, 0, 1, 0, 0, 1, 0] 3))))
+    (is (= 1 (bird-count/n-days-count [0, 0, 1, 0, 0, 1, 0] 3))))
   (testing "Count for first 6 days of busy week"
-    (is (= 48 (exercism.bird-count/n-days-count [5, 9, 12, 6, 8, 8, 17] 6)))))
+    (is (= 48 (bird-count/n-days-count [5, 9, 12, 6, 8, 8, 17] 6)))))
 
 (deftest busy-days-test
   (testing "Busy days for disappointing week"
-    (is (= 0 (exercism.bird-count/busy-days [1 1 1 0 0 0 0]))))
+    (is (= 0 (bird-count/busy-days [1 1 1 0 0 0 0]))))
   (testing "Busy days for busy week"
-    (is (= 5 (exercism.bird-count/busy-days [4 9 5 7 8 8 2])))))
+    (is (= 5 (bird-count/busy-days [4 9 5 7 8 8 2])))))
 
 (deftest odd-week-test
   (testing "Odd week for week matching odd pattern"
-    (is (= true (exercism.bird-count/odd-week? [1 0 1 0 1 0 1]))))
+    (is (= true (bird-count/odd-week? [1 0 1 0 1 0 1]))))
   (testing "Odd week for week that does not match pattern"
-    (is (= false (exercism.bird-count/odd-week? [2 2 1 0 1 1 1])))))
+    (is (= false (bird-count/odd-week? [2 2 1 0 1 1 1])))))

--- a/exercises/concept/bird-watcher/test/bird_watcher_test.clj
+++ b/exercises/concept/bird-watcher/test/bird_watcher_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.bird-count-test
+(ns bird-count-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.bird-count))
 

--- a/exercises/concept/cars-assemble/src/cars_assemble.clj
+++ b/exercises/concept/cars-assemble/src/cars_assemble.clj
@@ -1,4 +1,4 @@
-(ns exercism.assembly-line)
+(ns assembly-line)
 
 (defn production-rate
   "Returns the assembly line's production rate per hour,

--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.assembly-line-test
+(ns assembly-line-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.assembly-line))
 

--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -1,33 +1,33 @@
 (ns assembly-line-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.assembly-line))
+            assembly-line))
 
 (deftest production-rate-test
   (testing "Production rate for"
     (testing "speed 0"
-      (is (= 0.0 (exercism.assembly-line/production-rate 0))))
+      (is (= 0.0 (assembly-line/production-rate 0))))
     (testing "speed 1"
-      (is (= 221.0 (exercism.assembly-line/production-rate 1))))
+      (is (= 221.0 (assembly-line/production-rate 1))))
     (testing "speed 4"
-      (is (= 884.0 (exercism.assembly-line/production-rate 4))))
+      (is (= 884.0 (assembly-line/production-rate 4))))
     (testing "speed 7"
-      (is (= 1392.3 (exercism.assembly-line/production-rate 7))))
+      (is (= 1392.3 (assembly-line/production-rate 7))))
     (testing "speed 9"
-      (is (= 1591.2 (exercism.assembly-line/production-rate 9))))
+      (is (= 1591.2 (assembly-line/production-rate 9))))
     (testing "speed 10"
-      (is (= 1701.7 (exercism.assembly-line/production-rate 10))))))
+      (is (= 1701.7 (assembly-line/production-rate 10))))))
 
 (deftest working-items-test
   (testing "Working items for"
     (testing "speed 0"
-      (is (= 0 (exercism.assembly-line/working-items 0))))
+      (is (= 0 (assembly-line/working-items 0))))
     (testing "speed 1"
-      (is (= 3 (exercism.assembly-line/working-items 1))))
+      (is (= 3 (assembly-line/working-items 1))))
     (testing "speed 5"
-      (is (= 16 (exercism.assembly-line/working-items 5))))
+      (is (= 16 (assembly-line/working-items 5))))
     (testing "speed 8"
-      (is (= 26 (exercism.assembly-line/working-items 8))))
+      (is (= 26 (assembly-line/working-items 8))))
     (testing "speed 9"
-      (is (= 26 (exercism.assembly-line/working-items 9))))
+      (is (= 26 (assembly-line/working-items 9))))
     (testing "speed 10"
-      (is (= 28 (exercism.assembly-line/working-items 10))))))
+      (is (= 28 (assembly-line/working-items 10))))))

--- a/exercises/concept/interest-is-interesting/src/interest_is_interesting.clj
+++ b/exercises/concept/interest-is-interesting/src/interest_is_interesting.clj
@@ -1,4 +1,4 @@
-(ns exercism.savings-account)
+(ns savings-account)
 
 (defn interest-rate
   "TODO: add docstring"

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -1,64 +1,64 @@
 (ns savings-account-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.savings-account))
+            savings-account))
 
 (deftest interest-rate-test
   (testing "Minimal first interest rate"
-    (is (= 0.5 (exercism.savings-account/interest-rate 0M))))
+    (is (= 0.5 (savings-account/interest-rate 0M))))
   (testing "Tiny first interest rate"
-    (is (= 0.5 (exercism.savings-account/interest-rate 0.000001M))))
+    (is (= 0.5 (savings-account/interest-rate 0.000001M))))
   (testing "Maximum first interest rate"
-    (is (= 0.5 (exercism.savings-account/interest-rate 999.9999M))))
+    (is (= 0.5 (savings-account/interest-rate 999.9999M))))
   (testing "Minimal second interest rate"
-    (is (= 1.621 (exercism.savings-account/interest-rate 1000.0M))))
+    (is (= 1.621 (savings-account/interest-rate 1000.0M))))
   (testing "Tiny second interest rate"
-    (is (= 1.621 (exercism.savings-account/interest-rate 1000.0001M))))
+    (is (= 1.621 (savings-account/interest-rate 1000.0001M))))
   (testing "Maximum second interest rate"
-    (is (= 1.621 (exercism.savings-account/interest-rate 4999.9990M))))
+    (is (= 1.621 (savings-account/interest-rate 4999.9990M))))
   (testing "Minimal third interest rate"
-    (is (= 2.475 (exercism.savings-account/interest-rate 5000.0000M))))
+    (is (= 2.475 (savings-account/interest-rate 5000.0000M))))
   (testing "Tiny third interest rate"
-    (is (= 2.475 (exercism.savings-account/interest-rate 5000.0001M))))
+    (is (= 2.475 (savings-account/interest-rate 5000.0001M))))
   (testing "Large third interest rate"
-    (is (= 2.475 (exercism.savings-account/interest-rate 5639998.742909M))))
+    (is (= 2.475 (savings-account/interest-rate 5639998.742909M))))
   (testing "Minimal negative interest rate"
-    (is (= -3.213 (exercism.savings-account/interest-rate -0.000001M))))
+    (is (= -3.213 (savings-account/interest-rate -0.000001M))))
   (testing "Small negative interest rate"
-    (is (= -3.213 (exercism.savings-account/interest-rate -0.123M))))
+    (is (= -3.213 (savings-account/interest-rate -0.123M))))
   (testing "Regular negative interest rate"
-    (is (= -3.213 (exercism.savings-account/interest-rate -300.0M))))
+    (is (= -3.213 (savings-account/interest-rate -300.0M))))
   (testing "Large negative interest rate"
-    (is (= -3.213 (exercism.savings-account/interest-rate -152964.231M)))))
+    (is (= -3.213 (savings-account/interest-rate -152964.231M)))))
 
 (deftest annual-balance-update-test
   (testing "Empty balance"
-    (is (= 0.0000M (exercism.savings-account/annual-balance-update 0.0M))))
+    (is (= 0.0000M (savings-account/annual-balance-update 0.0M))))
   (testing "Small positive balance"
-    (is (= 0.000001005M (exercism.savings-account/annual-balance-update 0.000001M))))
+    (is (= 0.000001005M (savings-account/annual-balance-update 0.000001M))))
   (testing "Average positive balance"
-    (is (= 1016.210000M (exercism.savings-account/annual-balance-update 1000.0M))))
+    (is (= 1016.210000M (savings-account/annual-balance-update 1000.0M))))
   (testing "Large positive balance"
-    (is (= 1016.2101016209999M (exercism.savings-account/annual-balance-update 1000.0001M))))
+    (is (= 1016.2101016209999M (savings-account/annual-balance-update 1000.0001M))))
   (testing "Huge positive balance"
-    (is (= 920352587.267443M (exercism.savings-account/annual-balance-update 898124017.826243404425M))))
+    (is (= 920352587.267443M (savings-account/annual-balance-update 898124017.826243404425M))))
   (testing "Small negative balance"
-    (is (= -0.11904801M (exercism.savings-account/annual-balance-update -0.123M))))
+    (is (= -0.11904801M (savings-account/annual-balance-update -0.123M))))
   (testing "Large negative balance"
-    (is (= -148049.49025797M (exercism.savings-account/annual-balance-update -152964.231M)))))
+    (is (= -148049.49025797M (savings-account/annual-balance-update -152964.231M)))))
 
 (deftest amount-to-donate-test
   (testing "Empty balance"
-    (is (= 0 (exercism.savings-account/amount-to-donate 0.0M 2.0))))
+    (is (= 0 (savings-account/amount-to-donate 0.0M 2.0))))
   (testing "Small positive balance"
-    (is (= 0 (exercism.savings-account/amount-to-donate 0.000001M 2.1))))
+    (is (= 0 (savings-account/amount-to-donate 0.000001M 2.1))))
   (testing "Average positive balance"
-    (is (= 40 (exercism.savings-account/amount-to-donate 1000.0M 2.0))))
+    (is (= 40 (savings-account/amount-to-donate 1000.0M 2.0))))
   (testing "Large positive balance"
-    (is (= 19 (exercism.savings-account/amount-to-donate 1000.0001M 0.99))))
+    (is (= 19 (savings-account/amount-to-donate 1000.0001M 0.99))))
   (testing "Huge positive balance"
-    (is (= 47600572 (exercism.savings-account/amount-to-donate 898124017.826243404425M 2.65))))
+    (is (= 47600572 (savings-account/amount-to-donate 898124017.826243404425M 2.65))))
   (testing "Small negative balance"
-    (is (= 0 (exercism.savings-account/amount-to-donate -0.123M 3.33))))
+    (is (= 0 (savings-account/amount-to-donate -0.123M 3.33))))
   (testing "Large negative balance"
-    (is (= 0 (exercism.savings-account/amount-to-donate -152964.231M 5.4))))
+    (is (= 0 (savings-account/amount-to-donate -152964.231M 5.4))))
   )

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.savings-account-test
+(ns savings-account-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.savings-account))
 

--- a/exercises/concept/international-calling-connoisseur/src/dialing_codes.clj
+++ b/exercises/concept/international-calling-connoisseur/src/dialing_codes.clj
@@ -1,4 +1,4 @@
-(ns exercism.dialing-codes)
+(ns dialing-codes)
 
 (def countries)
 

--- a/exercises/concept/international-calling-connoisseur/test/dialing_codes_test.clj
+++ b/exercises/concept/international-calling-connoisseur/test/dialing_codes_test.clj
@@ -1,99 +1,99 @@
 (ns dialing-codes-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.dialing-codes))
+            dialing-codes))
 
 (deftest map-count-is-3
-  (is (= 3 (count exercism.dialing-codes/countries))))
+  (is (= 3 (count dialing-codes/countries))))
 
 (deftest United-States-of-America-is-1
-  (is (= "United States of America" (get exercism.dialing-codes/countries 1))))
+  (is (= "United States of America" (get dialing-codes/countries 1))))
 
 (deftest Brazil-is-55
-  (is (= "Brazil" (get exercism.dialing-codes/countries 55))))
+  (is (= "Brazil" (get dialing-codes/countries 55))))
 
 (deftest India-is-55
-  (is (= "India" (get exercism.dialing-codes/countries 91))))
+  (is (= "India" (get dialing-codes/countries 91))))
 
 (deftest add-country-to-empty-map-single
-  (is (= 1 (count (exercism.dialing-codes/add-country {} 44 "United Kingdom")))))
+  (is (= 1 (count (dialing-codes/add-country {} 44 "United Kingdom")))))
 
 (deftest add-country-to-empty-map-44-is-United-Kingdom
-  (is (= "United Kingdom" (get (exercism.dialing-codes/add-country {} 44 "United Kingdom") 44))))
+  (is (= "United Kingdom" (get (dialing-codes/add-country {} 44 "United Kingdom") 44))))
 
 (deftest add-country-to-country-map-count-is-4
-  (is (= 4 (count (exercism.dialing-codes/add-country exercism.dialing-codes/countries 44 "United Kingdom")))))
+  (is (= 4 (count (dialing-codes/add-country dialing-codes/countries 44 "United Kingdom")))))
 
 (deftest add-country-to-country-map-1-is-United-States-of-America
-  (is (= "United States of America" (get (exercism.dialing-codes/add-country exercism.dialing-codes/countries 44 "United Kingdom") 1))))
+  (is (= "United States of America" (get (dialing-codes/add-country dialing-codes/countries 44 "United Kingdom") 1))))
 
 (deftest add-country-to-country-map-44-is-United-Kingdom
-  (is (= "United Kingdom" (get (exercism.dialing-codes/add-country exercism.dialing-codes/countries 44 "United Kingdom") 44))))
+  (is (= "United Kingdom" (get (dialing-codes/add-country dialing-codes/countries 44 "United Kingdom") 44))))
 
 (deftest add-country-to-country-map-55-is-Brazil
-  (is (= "Brazil" (get (exercism.dialing-codes/add-country exercism.dialing-codes/countries 44 "United Kingdom") 55))))
+  (is (= "Brazil" (get (dialing-codes/add-country dialing-codes/countries 44 "United Kingdom") 55))))
 
 (deftest add-country-to-country-map-91-is-India
-  (is (= "India" (get (exercism.dialing-codes/add-country exercism.dialing-codes/countries 44 "United Kingdom") 91))))
+  (is (= "India" (get (dialing-codes/add-country dialing-codes/countries 44 "United Kingdom") 91))))
 
 (deftest get-country-name-from-map
-  (is (= "Brazil" (exercism.dialing-codes/country-name exercism.dialing-codes/countries 55))))
+  (is (= "Brazil" (dialing-codes/country-name dialing-codes/countries 55))))
 
 (deftest get-country-name-for-non-existent-country
-  (is (nil? (exercism.dialing-codes/country-name exercism.dialing-codes/countries 999))))
+  (is (nil? (dialing-codes/country-name dialing-codes/countries 999))))
 
 (deftest check-country-exists
-  (is (true? (exercism.dialing-codes/code-exists? exercism.dialing-codes/countries 55))))
+  (is (true? (dialing-codes/code-exists? dialing-codes/countries 55))))
 
 (deftest check-non-existent-country-exists
-  (is (false? (exercism.dialing-codes/code-exists? exercism.dialing-codes/countries 999))))
+  (is (false? (dialing-codes/code-exists? dialing-codes/countries 999))))
 
 (deftest update-name-in-map-count-is-3
-  (is (= 3 (count (exercism.dialing-codes/update-country exercism.dialing-codes/countries 1 "les États-Unis")))))
+  (is (= 3 (count (dialing-codes/update-country dialing-codes/countries 1 "les États-Unis")))))
 
 (deftest update-name-in-map-1-is-les-Etats-Unis
-  (is (= "les États-Unis" (get (exercism.dialing-codes/update-country exercism.dialing-codes/countries 1 "les États-Unis") 1))))
+  (is (= "les États-Unis" (get (dialing-codes/update-country dialing-codes/countries 1 "les États-Unis") 1))))
 
 (deftest update-name-in-map-55-is-Brazil
-  (is (= "Brazil" (get (exercism.dialing-codes/update-country exercism.dialing-codes/countries 1 "les États-Unis") 55))))
+  (is (= "Brazil" (get (dialing-codes/update-country dialing-codes/countries 1 "les États-Unis") 55))))
 
 (deftest update-name-in-map-91-is-India
-  (is (= "India" (get (exercism.dialing-codes/update-country exercism.dialing-codes/countries 1 "les États-Unis") 91))))
+  (is (= "India" (get (dialing-codes/update-country dialing-codes/countries 1 "les États-Unis") 91))))
 
 (deftest update-non-existent-name-in-map-count-is-3
-  (is (= 3 (count (exercism.dialing-codes/update-country exercism.dialing-codes/countries 999 "Newlands")))))
+  (is (= 3 (count (dialing-codes/update-country dialing-codes/countries 999 "Newlands")))))
 
 (deftest update-non-existent-name-in-map-1-is-United-States-of-America
-  (is (= "United States of America" (get (exercism.dialing-codes/update-country exercism.dialing-codes/countries 999 "Newlands") 1))))
+  (is (= "United States of America" (get (dialing-codes/update-country dialing-codes/countries 999 "Newlands") 1))))
 
 (deftest update-non-existent-name-in-map-55-is-Brazil
-  (is (= "Brazil" (get (exercism.dialing-codes/update-country exercism.dialing-codes/countries 999 "Newlands") 55))))
+  (is (= "Brazil" (get (dialing-codes/update-country dialing-codes/countries 999 "Newlands") 55))))
 
 (deftest update-non-existent-name-in-map-91-is-India
-  (is (= "India" (get (exercism.dialing-codes/update-country exercism.dialing-codes/countries 999 "Newlands") 91))))
+  (is (= "India" (get (dialing-codes/update-country dialing-codes/countries 999 "Newlands") 91))))
 
 (deftest remove-country-from-map-count-is-2
-  (is (= 2 (count (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 91)))))
+  (is (= 2 (count (dialing-codes/remove-country dialing-codes/countries 91)))))
 
 (deftest remove-country-from-map-1-is-United-States-of-America
-  (is (= "United States of America" (get (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 44) 1))))
+  (is (= "United States of America" (get (dialing-codes/remove-country dialing-codes/countries 44) 1))))
 
 (deftest remove-country-from-map-55-is-Brazil
-  (is (= "Brazil" (get (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 44) 55))))
+  (is (= "Brazil" (get (dialing-codes/remove-country dialing-codes/countries 44) 55))))
 
 (deftest remove-non-existent-country-from-map-count-is-3
-  (is (= 3 (count (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 999)))))
+  (is (= 3 (count (dialing-codes/remove-country dialing-codes/countries 999)))))
 
 (deftest remove-non-existent-country-from-map-1-is-United-States-of-America
-  (is (= "United States of America" (get (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 999) 1))))
+  (is (= "United States of America" (get (dialing-codes/remove-country dialing-codes/countries 999) 1))))
 
 (deftest remove-non-existent-country-from-map-55-is-Brazil
-  (is (= "Brazil" (get (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 999) 55))))
+  (is (= "Brazil" (get (dialing-codes/remove-country dialing-codes/countries 999) 55))))
 
 (deftest remove-non-existent-country-from-map-91-is-India
-  (is (= "India" (get (exercism.dialing-codes/remove-country exercism.dialing-codes/countries 999) 91))))
+  (is (= "India" (get (dialing-codes/remove-country dialing-codes/countries 999) 91))))
 
 (deftest longest-name
-  (is (= "United States of America" (exercism.dialing-codes/longest-name exercism.dialing-codes/countries))))
+  (is (= "United States of America" (dialing-codes/longest-name dialing-codes/countries))))
 
 (deftest longest-name-empty-map
-  (is (nil? (exercism.dialing-codes/longest-name {}))))
+  (is (nil? (dialing-codes/longest-name {}))))

--- a/exercises/concept/international-calling-connoisseur/test/dialing_codes_test.clj
+++ b/exercises/concept/international-calling-connoisseur/test/dialing_codes_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.dialing-codes-test
+(ns dialing-codes-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.dialing-codes))
 

--- a/exercises/concept/log-levels/src/log_levels.clj
+++ b/exercises/concept/log-levels/src/log_levels.clj
@@ -1,4 +1,4 @@
-(ns exercism.log-line
+(ns log-line
   (:require [clojure.string :as str]))
 
 (defn message

--- a/exercises/concept/log-levels/test/log_levels_test.clj
+++ b/exercises/concept/log-levels/test/log_levels_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.log-line-test
+(ns log-line-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.log-line))
 

--- a/exercises/concept/log-levels/test/log_levels_test.clj
+++ b/exercises/concept/log-levels/test/log_levels_test.clj
@@ -1,34 +1,34 @@
 (ns log-line-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.log-line))
+            log-line))
 
 (deftest message-test
   (testing "Message test"
     (testing "Error"
-      (is (= "Stack overflow" (exercism.log-line/message "[ERROR]: Stack overflow"))))
+      (is (= "Stack overflow" (log-line/message "[ERROR]: Stack overflow"))))
     (testing "Warning"
-      (is (= (exercism.log-line/message "[WARNING]: Disk almost full") "Disk almost full")))
+      (is (= (log-line/message "[WARNING]: Disk almost full") "Disk almost full")))
     (testing "Info"
-      (is (= (exercism.log-line/message "[INFO]: File moved") "File moved"))
+      (is (= (log-line/message "[INFO]: File moved") "File moved"))
       (testing "Trim whitespace"
-        (is (= "Timezone not set" (exercism.log-line/message "[WARNING]:   \tTimezone not set  \r\n")))))))
+        (is (= "Timezone not set" (log-line/message "[WARNING]:   \tTimezone not set  \r\n")))))))
 
 (deftest log-level-test
   (testing "Log levels"
     (testing "Error"
-      (is (= "error" (exercism.log-line/log-level "[ERROR]: Disk full"))))
+      (is (= "error" (log-line/log-level "[ERROR]: Disk full"))))
     (testing "Warning"
-      (is (= "warning" (exercism.log-line/log-level "[WARNING]: Unsafe password"))))
+      (is (= "warning" (log-line/log-level "[WARNING]: Unsafe password"))))
     (testing "Info"
-      (is (= "info" (exercism.log-line/log-level "[INFO]: Timezone changed"))))))
+      (is (= "info" (log-line/log-level "[INFO]: Timezone changed"))))))
 
 (deftest reformat-test
   (testing "Reformat test"
     (testing "Error"
-      (is (= "Segmentation fault (error)" (exercism.log-line/reformat "[ERROR]: Segmentation fault"))))
+      (is (= "Segmentation fault (error)" (log-line/reformat "[ERROR]: Segmentation fault"))))
     (testing "Warning"
-      (is (= "Decreased performance (warning)" (exercism.log-line/reformat "[WARNING]: Decreased performance"))))
+      (is (= "Decreased performance (warning)" (log-line/reformat "[WARNING]: Decreased performance"))))
     (testing "Info"
-      (is (= "Disk defragmented (info)" (exercism.log-line/reformat "[INFO]: Disk defragmented"))))
+      (is (= "Disk defragmented (info)" (log-line/reformat "[INFO]: Disk defragmented"))))
     (testing "Trim whitespace"
-      (is (= "Corrupt disk (error)" (exercism.log-line/reformat "[ERROR]: \t Corrupt disk\t \t \r\n"))))))
+      (is (= "Corrupt disk (error)" (log-line/reformat "[ERROR]: \t Corrupt disk\t \t \r\n"))))))

--- a/exercises/concept/lucians-luscious-lasagna/src/lucians_luscious_lasagna.clj
+++ b/exercises/concept/lucians-luscious-lasagna/src/lucians_luscious_lasagna.clj
@@ -1,4 +1,4 @@
-(ns exercism.lasagna)
+(ns lasagna)
 
 (def expected-time
   ;; Define the var here

--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -1,23 +1,23 @@
 (ns lasagna-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.lasagna))
+            lasagna))
 
 (deftest expected-time-test
-  (is (= 40 (exercism.lasagna/expected-time))))
+  (is (= 40 (lasagna/expected-time))))
 
 (deftest remaining-time-test
-  (is (= 15 (exercism.lasagna/remaining-time 25))))
+  (is (= 15 (lasagna/remaining-time 25))))
 
 (deftest prep-time-test
   (testing "Preparation time in minutes"
     (testing "for one layer"
-      (is (= 2 (exercism.lasagna/prep-time 1))))
+      (is (= 2 (lasagna/prep-time 1))))
     (testing "for multiple layers"
-      (is (= 8 (exercism.lasagna/prep-time 4))))))
+      (is (= 8 (lasagna/prep-time 4))))))
 
 (deftest total-time-test
   (testing "Total elapsed time in minutes"
     (testing "for one layer"
-      (is (= 32 (exercism.lasagna/total-time 1 30))))
+      (is (= 32 (lasagna/total-time 1 30))))
     (testing "for multiple layers"
-      (is (= 16 (exercism.lasagna/total-time 4 8))))))
+      (is (= 16 (lasagna/total-time 4 8))))))

--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.lasagna-test
+(ns lasagna-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.lasagna))
 

--- a/exercises/concept/squeaky-clean/src/squeaky_clean.clj
+++ b/exercises/concept/squeaky-clean/src/squeaky_clean.clj
@@ -1,4 +1,4 @@
-(ns exercism.squeaky-clean
+(ns squeaky-clean
   (:require [clojure.string :as str]))
 
 (defn clean

--- a/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
+++ b/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
@@ -1,30 +1,30 @@
 (ns squeaky-clean-test
   (:require [clojure.test :refer [deftest testing is]]
-            exercism.squeaky-clean))
+            squeaky-clean))
 
 (deftest clean-single-letter
-  (is (= "A" (exercism.squeaky-clean/clean "A"))))
+  (is (= "A" (squeaky-clean/clean "A"))))
 
 (deftest clean-clean-string
-  (is (= "àḃç" (exercism.squeaky-clean/clean "àḃç"))))
+  (is (= "àḃç" (squeaky-clean/clean "àḃç"))))
 
 (deftest clean-string-with-spaces
-  (is (= "my___Id" (exercism.squeaky-clean/clean "my   Id"))))
+  (is (= "my___Id" (squeaky-clean/clean "my   Id"))))
 
 (deftest clean-string-with-control-char
-  (is (= "myCTRLId" (exercism.squeaky-clean/clean "my\u0000Id"))))
+  (is (= "myCTRLId" (squeaky-clean/clean "my\u0000Id"))))
 
 (deftest clean-string-with-no-letters
-  (is (= "" (exercism.squeaky-clean/clean "😀😀😀"))))
+  (is (= "" (squeaky-clean/clean "😀😀😀"))))
 
 (deftest clean-empty-string
-  (is (= "" (exercism.squeaky-clean/clean ""))))
+  (is (= "" (squeaky-clean/clean ""))))
 
 (deftest convert-kebab-to-camel-case
-  (is (= "àḂç" (exercism.squeaky-clean/clean "à-ḃç"))))
+  (is (= "àḂç" (squeaky-clean/clean "à-ḃç"))))
 
 (deftest omit-lower-case-greek-letters
-  (is (= "MyΟFinder" (exercism.squeaky-clean/clean "MyΟβιεγτFinder"))))
+  (is (= "MyΟFinder" (squeaky-clean/clean "MyΟβιεγτFinder"))))
 
 (deftest combine-conversions
-  (is (= "_AbcĐCTRL" (exercism.squeaky-clean/clean "9 -abcĐ😀ω\0"))))
+  (is (= "_AbcĐCTRL" (squeaky-clean/clean "9 -abcĐ😀ω\0"))))

--- a/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
+++ b/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.squeaky-clean-test
+(ns squeaky-clean-test
   (:require [clojure.test :refer [deftest testing is]]
             exercism.squeaky-clean))
 

--- a/exercises/concept/tracks-on-tracks-on-tracks/src/tracks_on_tracks_on_tracks.clj
+++ b/exercises/concept/tracks-on-tracks-on-tracks/src/tracks_on_tracks_on_tracks.clj
@@ -1,4 +1,4 @@
-(ns exercism.languages)
+(ns languages)
 
 (defn new-list
   "Creates an empty list of languages to practice."

--- a/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
+++ b/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
@@ -1,4 +1,4 @@
-(ns exercism.languages-test
+(ns languages-test
   (:require [clojure.test :refer [deftest is]]
             exercism.languages))
 

--- a/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
+++ b/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
@@ -1,23 +1,23 @@
 (ns languages-test
   (:require [clojure.test :refer [deftest is]]
-            exercism.languages))
+            languages))
 
 (deftest list-empty-test
-  (is (= '() (exercism.languages/new-list))))
+  (is (= '() (languages/new-list))))
 
 (deftest list-add-test
   (is (= '("JavaScript" "Java" "Lisp" "Clojure")
-         (->> (exercism.languages/new-list)
-              (exercism.languages/add-language "Clojure")
-              (exercism.languages/add-language "Lisp")
-              (exercism.languages/add-language "Java")
-              (exercism.languages/add-language "JavaScript")))))
+         (->> (languages/new-list)
+              (languages/add-language "Clojure")
+              (languages/add-language "Lisp")
+              (languages/add-language "Java")
+              (languages/add-language "JavaScript")))))
 
 (deftest first-test
-  (is (= "Lisp" (exercism.languages/first-language '("Lisp" "Clojure")))))
+  (is (= "Lisp" (languages/first-language '("Lisp" "Clojure")))))
 
 (deftest list-remove-test
-  (is (= '("Clojure") (exercism.languages/remove-language '("Lisp" "Clojure")))))
+  (is (= '("Clojure") (languages/remove-language '("Lisp" "Clojure")))))
 
 (deftest list-count-test
-  (is (= 3 (exercism.languages/count-languages '("JavaScript" "Java" "Clojure")))))
+  (is (= 3 (languages/count-languages '("JavaScript" "Java" "Clojure")))))


### PR DESCRIPTION
We previously simplified the Concept exercises' directory structure but never changed the namespaces in the source/test files, which is causing the tests to fail. This fixes that.