### PR TITLE
Fix faulty unit test

### DIFF
--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -3,7 +3,7 @@
             lucians-luscious-lasagna))
 
 (deftest expected-time-test
-  (is (= 40 (lucians-luscious-lasagna/expected-time))))
+  (is (= 40 lucians-luscious-lasagna/expected-time)))
 
 (deftest remaining-time-test
   (is (= 15 (lucians-luscious-lasagna/remaining-time 25))))


### PR DESCRIPTION
The tests were failing because there was an error in the test! The `expected-time` unit test was trying to call a number as a function.