### PR TITLE
Make test suites conform to test runner expected input

### DIFF
--- a/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
+++ b/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
@@ -2,74 +2,122 @@
   (:require [clojure.test :refer [deftest testing is]]
             annalyns-infiltration))
 
-(deftest fast-attack-test
-  (testing "Fast attack if knight is"
-    (testing "awake"
-      (is (= false (annalyns-infiltration/can-fast-attack? true))))
-    (testing "sleeping"
-      (is (= true (annalyns-infiltration/can-fast-attack? false))))))
+(deftest fast-attack-awake-test
+  (testing "Fast attack if knight is awake"
+    (is (= false (annalyns-infiltration/can-fast-attack? true)))))
 
-(deftest spy-test
+(deftest fast-attack-asleep-test
+  (testing "Fast attack if knight is sleeping"
+    (is (= true (annalyns-infiltration/can-fast-attack? false)))))
+
+(deftest spy-everyone-sleeping-test
   (testing "Cannot spy if everyone is sleeping"
-    (is (= false (annalyns-infiltration/can-spy? false false false))))
+    (is (= false (annalyns-infiltration/can-spy? false false false)))))
+
+(deftest spy-but-knight-sleeping-test
   (testing "Can spy if everyone but knight is sleeping"
-    (is (= true (annalyns-infiltration/can-spy? true false false))))
+    (is (= true (annalyns-infiltration/can-spy? true false false)))))
+
+(deftest spy-but-archer-sleeping-test
   (testing "Can spy if everyone but archer is sleeping"
-    (is (= true (annalyns-infiltration/can-spy? false true false))))
+    (is (= true (annalyns-infiltration/can-spy? false true false)))))
+
+(deftest spy-but-prisoner-sleeping-test
   (testing "Can spy if everyone but prisoner is sleeping"
-    (is (= true (annalyns-infiltration/can-spy? false false true))))
+    (is (= true (annalyns-infiltration/can-spy? false false true)))))
+
+(deftest spy-only-knight-sleeping-test
   (testing "Can spy if only knight is sleeping"
-    (is (= true (annalyns-infiltration/can-spy? false true true))))
+    (is (= true (annalyns-infiltration/can-spy? false true true)))))
+
+(deftest spy-only-archer-sleeping-test
   (testing "Can spy if only archer is sleeping"
-    (is (= true (annalyns-infiltration/can-spy? true false true))))
+    (is (= true (annalyns-infiltration/can-spy? true false true)))))
+
+(deftest spy-only-prisoner-sleeping-test
   (testing "Can spy if only prisoner is sleeping"
-    (is (= true (annalyns-infiltration/can-spy? true true false))))
+    (is (= true (annalyns-infiltration/can-spy? true true false)))))
+
+(deftest spy-everyone-awake-test
   (testing "Can spy if everyone is awake"
     (is (= true (annalyns-infiltration/can-spy? true true true)))))
 
-(deftest signal-prisoner-test
+(deftest signal-prisoner-archer-sleeping-prisoner-awake-test
   (testing "Can signal prisoner if archer is sleeping and prisoner is awake"
-    (is (= true (annalyns-infiltration/can-signal-prisoner? false true))))
-  (testing "Cannot signal prisoner if"
-    (testing "archer is awake and prisoner is sleeping"
-      (is (= false (annalyns-infiltration/can-signal-prisoner? true false))))
-    (testing "archer and prisoner are both sleeping"
-      (is (= false (annalyns-infiltration/can-signal-prisoner? false false))))
-    (testing "archer and prisoner are both awake"
-      (is (= false (annalyns-infiltration/can-signal-prisoner? true true))))))
+    (is (= true (annalyns-infiltration/can-signal-prisoner? false true)))))
 
-(deftest release-prisoner-test
-  (testing "Cannot release prisoner if"
-    (testing "everyone is awake and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true true true))))
-    (testing "everyone is awake and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true true false))))
-    (testing "everyone is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false false false false))))
-    (testing "only archer is awake and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true false true))))
-    (testing "only archer is awake and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true false false))))
-    (testing "only knight is awake and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true false false false))))
-    (testing "only knight is asleep and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true true true))))
-    (testing "only knight is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true true false))))
-    (testing "only archer is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true false true false))))
-    (testing "only prisoner is asleep and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true false true))))
-    (testing "only prisoner is asleep and pet dog is absent"
+(deftest signal-prisoner-archer-awake-prisoner-sleeping-test
+  (testing "Cannot signal prisoner if archer is awake and prisoner is sleeping"
+      (is (= false (annalyns-infiltration/can-signal-prisoner? true false)))))
+
+(deftest signal-prisoner-both-sleeping-test
+  (testing "Cannot signal prisoner if archer and prisoner are both sleeping"
+      (is (= false (annalyns-infiltration/can-signal-prisoner? false false)))))
+
+(deftest signal-prisoner-both-awake-test
+  (testing "Cannot signal prisoner if archer and prisoner are both awake"
+      (is (= false (annalyns-infiltration/can-signal-prisoner? true true)))))
+
+(deftest release-prisoner-everyone-awake-dog-present-test
+  (testing "Cannot release prisoner if everyone is awake and pet dog is present"
+      (is (= false (annalyns-infiltration/can-free-prisoner? true true true true)))))
+
+(deftest release-prisoner-everyone-awake-dog-absent-test
+    (testing "Cannot release prisoner if everyone is awake and pet dog is absent"
+      (is (= false (annalyns-infiltration/can-free-prisoner? true true true false)))))
+    
+(deftest release-prisoner-everyone-asleep-dog-absent-test
+    (testing "Cannot release prisoner if everyone is asleep and pet dog is absent"
+      (is (= false (annalyns-infiltration/can-free-prisoner? false false false false)))))
+
+(deftest release-prisoner-archer-awake-dog-present-test
+    (testing "Cannot release prisoner if only archer is awake and pet dog is present"
+      (is (= false (annalyns-infiltration/can-free-prisoner? false true false true)))))
+
+(deftest release-prisoner-archer-awake-dog-absent-test
+    (testing "Cannot release prisoner if only archer is awake and pet dog is absent"
+      (is (= false (annalyns-infiltration/can-free-prisoner? false true false false)))))
+
+(deftest release-prisoner-knight-awake-dog-absent-test
+    (testing "Cannot release prisoner if only knight is awake and pet dog is absent"
+      (is (= false (annalyns-infiltration/can-free-prisoner? true false false false)))))
+
+(deftest release-prisoner-knight-awake-dog-present-test
+    (testing "Cannot release prisoner if only knight is asleep and pet dog is present"
+      (is (= false (annalyns-infiltration/can-free-prisoner? false true true true)))))
+
+(deftest release-prisoner-knight-asleep-dog-absent-test
+    (testing "Cannot release prisoner if only knight is asleep and pet dog is absent"
+      (is (= false (annalyns-infiltration/can-free-prisoner? false true true false)))))
+
+(deftest release-prisoner-archer-asleep-dog-absent-test
+    (testing "Cannot release prisoner if only archer is asleep and pet dog is absent"
+      (is (= false (annalyns-infiltration/can-free-prisoner? true false true false)))))
+
+(deftest release-prisoner-prisoner-asleep-dog-present-test
+    (testing "Cannot release prisoner if only prisoner is asleep and pet dog is present"
+      (is (= false (annalyns-infiltration/can-free-prisoner? true true false true)))))
+
+(deftest release-prisoner-prisoner-asleep-dog-absent-test
+    (testing "Cannot release prisoner if only prisoner is asleep and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? true true false false)))))
-  (testing "Can release prisoner if"
-    (testing "everyone is asleep and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? false false false true))))
-    (testing "only prisoner is awake and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? false false true true))))
-    (testing "only prisoner is awake and pet dog is absent"
-      (is (= true (annalyns-infiltration/can-free-prisoner? false false true false))))
-    (testing "only knight is awake and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? true false false true))))
-    (testing "only archer is asleep and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? true false true true))))))
+
+(deftest release-prisoner-everyone-asleep-dog-present-test
+    (testing "Can release prisoner if everyone is asleep and pet dog is present"
+      (is (= true (annalyns-infiltration/can-free-prisoner? false false false true)))))
+
+(deftest release-prisoner-prisoner-awake-dog-present-test
+    (testing "Can release prisoner if only prisoner is awake and pet dog is present"
+      (is (= true (annalyns-infiltration/can-free-prisoner? false false true true)))))
+
+(deftest release-prisoner-prisoner-awake-dog-absent-test
+    (testing "Can release prisoner if only prisoner is awake and pet dog is absent"
+      (is (= true (annalyns-infiltration/can-free-prisoner? false false true false)))))
+
+(deftest release-prisoner-knight-awake-dog-present-test
+    (testing "Can release prisoner if only knight is awake and pet dog is present"
+      (is (= true (annalyns-infiltration/can-free-prisoner? true false false true)))))
+
+(deftest release-prisoner-archer-asleep-dog-present-test
+    (testing "Can release prisoner if only archer is asleep and pet dog is present"
+      (is (= true (annalyns-infiltration/can-free-prisoner? true false true true)))))

--- a/exercises/concept/bird-watcher/test/bird_watcher_test.clj
+++ b/exercises/concept/bird-watcher/test/bird_watcher_test.clj
@@ -5,38 +5,50 @@
 (deftest last-week-test
   (is (= [0 2 5 3 7 8 4] bird-watcher/last-week)))
 
-(deftest today-test
+(deftest today-disappointing-week-test
   (testing "Today's bird count of disappointing week"
-    (is (= 0 (bird-watcher/today [0 0 2 0 0 1 0]))))
+    (is (= 0 (bird-watcher/today [0 0 2 0 0 1 0])))))
+
+(deftest today-busy-week-test
   (testing "Today's bird count of busy week"
     (is (= 10 (bird-watcher/today [8 8 9 5 4 7 10])))))
 
-(deftest increment-bird-test
+(deftest increment-bird-no-visits-test
   (testing "Increment today's count with no previous visits"
-    (is (= [6 5 5 11 2 5 1] (bird-watcher/inc-bird [6 5 5 11 2 5 0]))))
+    (is (= [6 5 5 11 2 5 1] (bird-watcher/inc-bird [6 5 5 11 2 5 0])))))
+
+(deftest increment-bird-multiple-visits-test
   (testing "Increment today's count with multiple previous visits"
     (is (= [5 2 4 2 4 5 8] (bird-watcher/inc-bird [5 2 4 2 4 5 7])))))
 
 (deftest day-without-birds-test
   (testing "Has day without birds with day without birds"
-    (is (= true (bird-watcher/day-without-birds? [5 5 4 0 7 6 7]))))
+    (is (= true (bird-watcher/day-without-birds? [5 5 4 0 7 6 7])))))
+
+(deftest no-day-without-birds-test
   (testing "Has day without birds with no day without birds"
     (is (= false (bird-watcher/day-without-birds? [5 5 4 1 7 6 7])))))
 
-(deftest n-days-count-test
+(deftest n-days-count-disappointing-week-test
   (testing "Count for first three days of disappointing week"
-    (is (= 1 (bird-watcher/n-days-count [0, 0, 1, 0, 0, 1, 0] 3))))
+    (is (= 1 (bird-watcher/n-days-count [0, 0, 1, 0, 0, 1, 0] 3)))))
+
+(deftest n-days-count-busy-week-test
   (testing "Count for first 6 days of busy week"
     (is (= 48 (bird-watcher/n-days-count [5, 9, 12, 6, 8, 8, 17] 6)))))
 
-(deftest busy-days-test
+(deftest busy-days-disappointing-week-test
   (testing "Busy days for disappointing week"
-    (is (= 0 (bird-watcher/busy-days [1 1 1 0 0 0 0]))))
+    (is (= 0 (bird-watcher/busy-days [1 1 1 0 0 0 0])))))
+
+(deftest busy-days-busy-week-test
   (testing "Busy days for busy week"
     (is (= 5 (bird-watcher/busy-days [4 9 5 7 8 8 2])))))
 
-(deftest odd-week-test
+(deftest odd-week-matching-test
   (testing "Odd week for week matching odd pattern"
-    (is (= true (bird-watcher/odd-week? [1 0 1 0 1 0 1]))))
+    (is (= true (bird-watcher/odd-week? [1 0 1 0 1 0 1])))))
+
+(deftest odd-week-not-matching-test
   (testing "Odd week for week that does not match pattern"
     (is (= false (bird-watcher/odd-week? [2 2 1 0 1 1 1])))))

--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -2,32 +2,50 @@
   (:require [clojure.test :refer [deftest testing is]]
             cars-assemble))
 
-(deftest production-rate-test
-  (testing "Production rate for"
-    (testing "speed 0"
-      (is (= 0.0 (cars-assemble/production-rate 0))))
-    (testing "speed 1"
-      (is (= 221.0 (cars-assemble/production-rate 1))))
-    (testing "speed 4"
-      (is (= 884.0 (cars-assemble/production-rate 4))))
-    (testing "speed 7"
-      (is (= 1392.3 (cars-assemble/production-rate 7))))
-    (testing "speed 9"
-      (is (= 1591.2 (cars-assemble/production-rate 9))))
-    (testing "speed 10"
-      (is (= 1701.7 (cars-assemble/production-rate 10))))))
+(deftest production-rate-speed-0-test
+    (testing "Production rate for speed 0"
+      (is (= 0.0 (cars-assemble/production-rate 0)))))
 
-(deftest working-items-test
-  (testing "Working items for"
-    (testing "speed 0"
-      (is (= 0 (cars-assemble/working-items 0))))
-    (testing "speed 1"
-      (is (= 3 (cars-assemble/working-items 1))))
-    (testing "speed 5"
-      (is (= 16 (cars-assemble/working-items 5))))
-    (testing "speed 8"
-      (is (= 26 (cars-assemble/working-items 8))))
-    (testing "speed 9"
-      (is (= 26 (cars-assemble/working-items 9))))
-    (testing "speed 10"
-      (is (= 28 (cars-assemble/working-items 10))))))
+(deftest production-rate-speed-1-test
+    (testing "Production rate for speed 1"
+      (is (= 221.0 (cars-assemble/production-rate 1)))))
+
+(deftest production-rate-speed-4-test
+    (testing "Production rate for speed 4"
+      (is (= 884.0 (cars-assemble/production-rate 4)))))
+
+(deftest production-rate-speeed-7-test
+    (testing "Production rate for speed 7"
+      (is (= 1392.3 (cars-assemble/production-rate 7)))))
+
+(deftest production-rate-speed-9-test
+    (testing "Production rate for speed 9"
+      (is (= 1591.2 (cars-assemble/production-rate 9)))))
+
+(deftest production-rate-speed-10-test
+    (testing "Production rate for speed 10"
+      (is (= 1701.7 (cars-assemble/production-rate 10)))))
+
+(deftest working-items-speed-0-test
+    (testing "Working items for speed 0"
+      (is (= 0 (cars-assemble/working-items 0)))))
+
+(deftest working-items-speed-1-test
+    (testing "Working items for speed 1"
+      (is (= 3 (cars-assemble/working-items 1)))))
+
+(deftest working-items-speed-5-test
+    (testing "Working items for speed 5"
+      (is (= 16 (cars-assemble/working-items 5)))))
+
+(deftest working-items-speed-8-test
+    (testing "Working items for speed 8"
+      (is (= 26 (cars-assemble/working-items 8)))))
+
+(deftest working-items-speed-9-test
+    (testing "Working items for speed 9"
+      (is (= 26 (cars-assemble/working-items 9)))))
+
+(deftest working-items-speed-10-test
+    (testing "Working items for speed 10"
+      (is (= 28 (cars-assemble/working-items 10)))))

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -2,63 +2,83 @@
   (:require [clojure.test :refer [deftest testing is]]
             interest-is-interesting))
 
-(deftest interest-rate-test
-  (testing "Minimal first interest rate"
-    (is (= 0.5 (interest-is-interesting/interest-rate 0M))))
-  (testing "Tiny first interest rate"
-    (is (= 0.5 (interest-is-interesting/interest-rate 0.000001M))))
-  (testing "Maximum first interest rate"
-    (is (= 0.5 (interest-is-interesting/interest-rate 999.9999M))))
-  (testing "Minimal second interest rate"
-    (is (= 1.621 (interest-is-interesting/interest-rate 1000.0M))))
-  (testing "Tiny second interest rate"
-    (is (= 1.621 (interest-is-interesting/interest-rate 1000.0001M))))
-  (testing "Maximum second interest rate"
-    (is (= 1.621 (interest-is-interesting/interest-rate 4999.9990M))))
-  (testing "Minimal third interest rate"
-    (is (= 2.475 (interest-is-interesting/interest-rate 5000.0000M))))
-  (testing "Tiny third interest rate"
-    (is (= 2.475 (interest-is-interesting/interest-rate 5000.0001M))))
-  (testing "Large third interest rate"
-    (is (= 2.475 (interest-is-interesting/interest-rate 5639998.742909M))))
-  (testing "Minimal negative interest rate"
-    (is (= -3.213 (interest-is-interesting/interest-rate -0.000001M))))
-  (testing "Small negative interest rate"
-    (is (= -3.213 (interest-is-interesting/interest-rate -0.123M))))
-  (testing "Regular negative interest rate"
-    (is (= -3.213 (interest-is-interesting/interest-rate -300.0M))))
-  (testing "Large negative interest rate"
-    (is (= -3.213 (interest-is-interesting/interest-rate -152964.231M)))))
+(deftest minimal-first-interest-rate-test
+  (is (= 0.5 (interest-is-interesting/interest-rate 0M))))
 
-(deftest annual-balance-update-test
-  (testing "Empty balance"
-    (is (= 0.0000M (interest-is-interesting/annual-balance-update 0.0M))))
-  (testing "Small positive balance"
-    (is (= 0.000001005M (interest-is-interesting/annual-balance-update 0.000001M))))
-  (testing "Average positive balance"
-    (is (= 1016.210000M (interest-is-interesting/annual-balance-update 1000.0M))))
-  (testing "Large positive balance"
-    (is (= 1016.2101016209999M (interest-is-interesting/annual-balance-update 1000.0001M))))
-  (testing "Huge positive balance"
-    (is (= 920352587.267443M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))
-  (testing "Small negative balance"
-    (is (= -0.11904801M (interest-is-interesting/annual-balance-update -0.123M))))
-  (testing "Large negative balance"
-    (is (= -148049.49025797M (interest-is-interesting/annual-balance-update -152964.231M)))))
+(deftest tiny-first-interest-rate-test
+  (is (= 0.5 (interest-is-interesting/interest-rate 0.000001M))))
 
-(deftest amount-to-donate-test
-  (testing "Empty balance"
-    (is (= 0 (interest-is-interesting/amount-to-donate 0.0M 2.0))))
-  (testing "Small positive balance"
-    (is (= 0 (interest-is-interesting/amount-to-donate 0.000001M 2.1))))
-  (testing "Average positive balance"
-    (is (= 40 (interest-is-interesting/amount-to-donate 1000.0M 2.0))))
-  (testing "Large positive balance"
-    (is (= 19 (interest-is-interesting/amount-to-donate 1000.0001M 0.99))))
-  (testing "Huge positive balance"
-    (is (= 47600572 (interest-is-interesting/amount-to-donate 898124017.826243404425M 2.65))))
-  (testing "Small negative balance"
-    (is (= 0 (interest-is-interesting/amount-to-donate -0.123M 3.33))))
-  (testing "Large negative balance"
-    (is (= 0 (interest-is-interesting/amount-to-donate -152964.231M 5.4))))
-  )
+(deftest maximum-first-interest-rate-test
+  (is (= 0.5 (interest-is-interesting/interest-rate 999.9999M))))
+
+(deftest minimal-second-interest-rate-test
+  (is (= 1.621 (interest-is-interesting/interest-rate 1000.0M))))
+
+(deftest tiny-second-interest-rate-test
+  (is (= 1.621 (interest-is-interesting/interest-rate 1000.0001M))))
+
+(deftest maximum-second-interest-rate-test
+  (is (= 1.621 (interest-is-interesting/interest-rate 4999.9990M))))
+
+(deftest minimal-third-interest-rate-test
+  (is (= 2.475 (interest-is-interesting/interest-rate 5000.0000M))))
+
+(deftest tiny-third-interest-rate-test
+  (is (= 2.475 (interest-is-interesting/interest-rate 5000.0001M))))
+
+(deftest large-third-interest-rate-test
+  (is (= 2.475 (interest-is-interesting/interest-rate 5639998.742909M))))
+
+(deftest minimal-negative-interest-rate-test
+  (is (= -3.213 (interest-is-interesting/interest-rate -0.000001M))))
+
+(deftest small-negative-interest-rate-test
+  (is (= -3.213 (interest-is-interesting/interest-rate -0.123M))))
+
+(deftest regular-negative-interest-rate-test
+  (is (= -3.213 (interest-is-interesting/interest-rate -300.0M))))
+
+(deftest large-negative-interest-rate-test
+  (is (= -3.213 (interest-is-interesting/interest-rate -152964.231M))))
+
+(deftest annual-balance-update-empty-balance-test
+  (is (= 0.0000M (interest-is-interesting/annual-balance-update 0.0M))))
+
+(deftest annual-balance-update-small-positive-balance-test
+  (is (= 0.000001005M (interest-is-interesting/annual-balance-update 0.000001M))))
+
+(deftest annual-balance-update-average-positive-balance-test
+  (is (= 1016.210000M (interest-is-interesting/annual-balance-update 1000.0M))))
+
+(deftest annual-balance-update-large-positive-balance-test
+  (is (= 1016.2101016209999M (interest-is-interesting/annual-balance-update 1000.0001M))))
+
+(deftest annual-balance-update-huge-positive-balance-test
+  (is (= 920352587.267443M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))
+
+(deftest annual-balance-update-small-negative-balance-test
+  (is (= -0.11904801M (interest-is-interesting/annual-balance-update -0.123M))))
+
+(deftest annual-balance-update-large-negative-balance-test
+  (is (= -148049.49025797M (interest-is-interesting/annual-balance-update -152964.231M))))
+
+(deftest amount-to-donate-empty-balance-test
+  (is (= 0 (interest-is-interesting/amount-to-donate 0.0M 2.0))))
+
+(deftest amount-to-donate-small-positive-balance-test
+  (is (= 0 (interest-is-interesting/amount-to-donate 0.000001M 2.1))))
+
+(deftest amount-to-donate-average-positive-balance-test
+  (is (= 40 (interest-is-interesting/amount-to-donate 1000.0M 2.0))))
+
+(deftest amount-to-donate-large-positive-balance-test
+  (is (= 19 (interest-is-interesting/amount-to-donate 1000.0001M 0.99))))
+
+(deftest amount-to-donate-huge-positive-balance-test
+  (is (= 47600572 (interest-is-interesting/amount-to-donate 898124017.826243404425M 2.65))))
+
+(deftest amount-to-donate-small-negative-balance-test
+  (is (= 0 (interest-is-interesting/amount-to-donate -0.123M 3.33))))
+
+(deftest amount-to-donate-large-negative-balance-test
+  (is (= 0 (interest-is-interesting/amount-to-donate -152964.231M 5.4))))

--- a/exercises/concept/log-levels/test/log_levels_test.clj
+++ b/exercises/concept/log-levels/test/log_levels_test.clj
@@ -2,33 +2,35 @@
   (:require [clojure.test :refer [deftest testing is]]
             log-levels))
 
-(deftest message-test
-  (testing "Message test"
-    (testing "Error"
-      (is (= "Stack overflow" (log-levels/message "[ERROR]: Stack overflow"))))
-    (testing "Warning"
-      (is (= (log-levels/message "[WARNING]: Disk almost full") "Disk almost full")))
-    (testing "Info"
-      (is (= (log-levels/message "[INFO]: File moved") "File moved"))
-      (testing "Trim whitespace"
-        (is (= "Timezone not set" (log-levels/message "[WARNING]:   \tTimezone not set  \r\n")))))))
+(deftest message-error-test
+  (is (= "Stack overflow" (log-levels/message "[ERROR]: Stack overflow"))))
 
-(deftest log-level-test
-  (testing "Log levels"
-    (testing "Error"
-      (is (= "error" (log-levels/log-level "[ERROR]: Disk full"))))
-    (testing "Warning"
-      (is (= "warning" (log-levels/log-level "[WARNING]: Unsafe password"))))
-    (testing "Info"
-      (is (= "info" (log-levels/log-level "[INFO]: Timezone changed"))))))
+(deftest message-warning-test
+  (is (= (log-levels/message "[WARNING]: Disk almost full") "Disk almost full")))
 
-(deftest reformat-test
-  (testing "Reformat test"
-    (testing "Error"
-      (is (= "Segmentation fault (error)" (log-levels/reformat "[ERROR]: Segmentation fault"))))
-    (testing "Warning"
-      (is (= "Decreased performance (warning)" (log-levels/reformat "[WARNING]: Decreased performance"))))
-    (testing "Info"
-      (is (= "Disk defragmented (info)" (log-levels/reformat "[INFO]: Disk defragmented"))))
-    (testing "Trim whitespace"
-      (is (= "Corrupt disk (error)" (log-levels/reformat "[ERROR]: \t Corrupt disk\t \t \r\n"))))))
+(deftest message-info-test
+  (is (= (log-levels/message "[INFO]: File moved") "File moved")))
+
+(deftest message-trim whitespace-test
+  (is (= "Timezone not set" (log-levels/message "[WARNING]:   \tTimezone not set  \r\n"))))
+
+(deftest log-level-error-test
+  (is (= "error" (log-levels/log-level "[ERROR]: Disk full"))))
+
+(deftest log-level-warning-test
+  (is (= "warning" (log-levels/log-level "[WARNING]: Unsafe password"))))
+
+(deftest log-level-info-test
+  (is (= "info" (log-levels/log-level "[INFO]: Timezone changed"))))
+
+(deftest reformat-error-test
+  (is (= "Segmentation fault (error)" (log-levels/reformat "[ERROR]: Segmentation fault"))))
+
+(deftest reformat-warning-test
+  (is (= "Decreased performance (warning)" (log-levels/reformat "[WARNING]: Decreased performance"))))
+
+(deftest reformat-info-test
+  (is (= "Disk defragmented (info)" (log-levels/reformat "[INFO]: Disk defragmented"))))
+
+(deftest reformat-trim-whitespace-test
+  (is (= "Corrupt disk (error)" (log-levels/reformat "[ERROR]: \t Corrupt disk\t \t \r\n"))))

--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -8,16 +8,14 @@
 (deftest remaining-time-test
   (is (= 15 (lucians-luscious-lasagna/remaining-time 25))))
 
-(deftest prep-time-test
-  (testing "Preparation time in minutes"
-    (testing "for one layer"
-      (is (= 2 (lucians-luscious-lasagna/prep-time 1))))
-    (testing "for multiple layers"
-      (is (= 8 (lucians-luscious-lasagna/prep-time 4))))))
+(deftest prep-time-one-layer-test
+  (is (= 2 (lucians-luscious-lasagna/prep-time 1))))
 
-(deftest total-time-test
-  (testing "Total elapsed time in minutes"
-    (testing "for one layer"
-      (is (= 32 (lucians-luscious-lasagna/total-time 1 30))))
-    (testing "for multiple layers"
-      (is (= 16 (lucians-luscious-lasagna/total-time 4 8))))))
+(deftest prep-time-multiple-layers-test
+  (is (= 8 (lucians-luscious-lasagna/prep-time 4))))
+
+(deftest total-time-one-layer-test
+  (is (= 32 (lucians-luscious-lasagna/total-time 1 30))))
+
+(deftest total-time-multiple-layers-test
+  (is (= 16 (lucians-luscious-lasagna/total-time 4 8))))

--- a/exercises/practice/acronym/test/acronym_test.clj
+++ b/exercises/practice/acronym/test/acronym_test.clj
@@ -2,11 +2,23 @@
   (:require [clojure.test :refer [deftest is]]
             acronym))
 
-(deftest test-acronym
-  (is (= "" (acronym/acronym "")))
-  (is (= "PNG" (acronym/acronym "Portable Network Graphics")))
-  (is (= "ROR" (acronym/acronym "Ruby on Rails")))
-  (is (= "HTML" (acronym/acronym "HyperText Markup Language")))
-  (is (= "FIFO" (acronym/acronym "First In, First Out")))
-  (is (= "PHP" (acronym/acronym "PHP: Hypertext Preprocessor")))
+(deftest test-acronym-empty-string
+  (is (= "" (acronym/acronym ""))))
+
+(deftest test-acronym-png
+  (is (= "PNG" (acronym/acronym "Portable Network Graphics"))))
+
+(deftest test-acronym-ror
+  (is (= "ROR" (acronym/acronym "Ruby on Rails"))))
+
+(deftest test-acronym-html
+  (is (= "HTML" (acronym/acronym "HyperText Markup Language"))))
+
+(deftest test-acronym-fifo
+  (is (= "FIFO" (acronym/acronym "First In, First Out"))))
+
+(deftest test-acronym-php
+  (is (= "PHP" (acronym/acronym "PHP: Hypertext Preprocessor"))))
+
+(deftest test-acronym-cmos
   (is (= "CMOS" (acronym/acronym "Complementary metal-oxide semiconductor"))))

--- a/exercises/practice/allergies/test/allergies_test.clj
+++ b/exercises/practice/allergies/test/allergies_test.clj
@@ -29,9 +29,13 @@
           :tomatoes :chocolate :pollen :cats]
          (allergies/allergies 255))))
 
-(deftest no-allergies-means-not-allergic
-  (is (not (allergies/allergic-to? 0 :peanuts)))
-  (is (not (allergies/allergic-to? 0 :cats)))
+(deftest no-allergies-means-not-allergic-peanuts
+  (is (not (allergies/allergic-to? 0 :peanuts))))
+
+(deftest no-allergies-means-not-allergic-cats
+  (is (not (allergies/allergic-to? 0 :cats))))
+
+(deftest no-allergies-means-not-allergic-strawberries
   (is (not (allergies/allergic-to? 0 :strawberries))))
 
 (deftest is-allergic-to-eggs

--- a/exercises/practice/beer-song/test/beer_song_test.clj
+++ b/exercises/practice/beer-song/test/beer_song_test.clj
@@ -36,12 +36,20 @@
        "No more bottles of beer on the wall, no more bottles of beer.\n"
        "Go to the store and buy some more, 99 bottles of beer on the wall.\n"))
 
-(deftest test-verse
-  (is (= verse-8 (beer-song/verse 8)))
-  (is (= verse-2 (beer-song/verse 2)))
-  (is (= verse-1 (beer-song/verse 1)))
+(deftest test-verse-8
+  (is (= verse-8 (beer-song/verse 8))))
+
+(deftest test-verse-2
+  (is (= verse-2 (beer-song/verse 2))))
+
+(deftest test-verse-1
+  (is (= verse-1 (beer-song/verse 1))))
+
+(deftest test-verse-0
   (is (= verse-0 (beer-song/verse 0))))
 
-(deftest test-song
-  (is (= song-8-6 (beer-song/sing 8 6)))
+(deftest test-song-8-6
+  (is (= song-8-6 (beer-song/sing 8 6))))
+
+(deftest test-song-3-0
   (is (= song-3-0 (beer-song/sing 3))))

--- a/exercises/practice/robot-name/test/robot_name_test.clj
+++ b/exercises/practice/robot-name/test/robot_name_test.clj
@@ -5,27 +5,39 @@
 (deftest robot-name
   (let [a-robot (robot-name/robot)
         its-name (robot-name/robot-name a-robot)]
-    (testing "robot-name"
-      (is (re-seq #"[A-Z]{2}\d{3}" its-name)
-          "name matches expected pattern")
-      (is (= its-name (robot-name/robot-name a-robot))
-          "name doesn't change until you reset it")
-      (is (not= its-name (-> (robot-name/robot) robot-name/robot-name))
-          "different robots have different names"))))
+      (is (re-seq #"[A-Z]{2}\d{3}" its-name))))
 
-(deftest reset-name
+(deftest name-matches-pattern
+   (let [a-robot (robot-name/robot)
+         its-name (robot-name/robot-name a-robot)]
+     (is (= its-name (robot-name/robot-name a-robot)))))
+
+(deftest different-robots-different-names
+ (let [a-robot (robot-name/robot)
+        its-name (robot-name/robot-name a-robot)]
+      (is (not= its-name (-> (robot-name/robot) robot-name/robot-name)))))
+
+(deftest new-name-matches
   (let [a-robot (robot-name/robot)
         its-original-name (robot-name/robot-name a-robot)
         its-new-name (do (robot-name/reset-name a-robot)
                          (robot-name/robot-name a-robot))]
+      (is (re-seq #"[A-Z]{2}\d{3}" its-new-name))))
 
-    (testing "reset-name"
-      (is (re-seq #"[A-Z]{2}\d{3}" its-new-name)
-          "new name matches expected pattern")
-      (is (not= its-original-name its-new-name)
-          "new name is different from old name")
-      (is (= its-new-name (robot-name/robot-name a-robot))
-          "new name doesn't change until you reset it")
-      (is (not= its-new-name (do (robot-name/reset-name a-robot)
-                                 (robot-name/robot-name a-robot)))
-          "new names are different each time"))))
+(deftest new-name-different
+  (let [a-robot (robot-name/robot)
+        its-original-name (robot-name/robot-name a-robot)
+        its-new-name (do (robot-name/reset-name a-robot)
+                         (robot-name/robot-name a-robot))]
+      (is (not= its-original-name its-new-name))))
+
+(deftest new-name-does-not-change-until-reset
+  (let [a-robot (robot-name/robot)
+        its-original-name (robot-name/robot-name a-robot)
+        its-new-name (do (robot-name/reset-name a-robot)
+                         (robot-name/robot-name a-robot))]
+      (is (= its-new-name (robot-name/robot-name a-robot)))))
+
+(deftest new-names-different-each-time
+  (is (not= its-new-name (do (robot-name/reset-name a-robot)
+                             (robot-name/robot-name a-robot)))))

--- a/exercises/practice/robot-simulator/test/robot_simulator_test.clj
+++ b/exercises/practice/robot-simulator/test/robot_simulator_test.clj
@@ -4,33 +4,51 @@
 
 (def robbie (robot-simulator/robot {:x -2 :y 1} :east))
 
-(deftest can-get-vals
-  (is (= :east (:bearing robbie)))
+(deftest can-get-vals-bearing
+  (is (= :east (:bearing robbie))))
+
+(deftest can-get-vals-coords
   (is (= {:x -2 :y 1} (:coordinates robbie))))
 
-(deftest can-turn
-  (is (= :north (robot-simulator/turn-right :west)))
+(deftest can-turn-right
+  (is (= :north (robot-simulator/turn-right :west))))
+
+(deftest can-turn-left
   (is (= :west  (robot-simulator/turn-left :north))))
 
-(deftest can-simulate
-  (is (= :west (:bearing (robot-simulator/simulate "RLAALAL" robbie))))
+(deftest can-simulate-bearing
+  (is (= :west (:bearing (robot-simulator/simulate "RLAALAL" robbie)))))
+
+(deftest can-simulate-coords
   (is (= {:x 0 :y 2}
          (:coordinates (robot-simulator/simulate "RLAALAL" robbie)))))
 
-(deftest simulate-clutz
+(deftest simulate-clutz-bearing
   (let [clutz (->> (robot-simulator/robot {:x 0 :y  0} :north)
                    (robot-simulator/simulate "LAAARALA"))]
-    (is (= :west (:bearing clutz)))
+    (is (= :west (:bearing clutz)))))
+
+(deftest simulate-clutz-coords
+  (let [clutz (->> (robot-simulator/robot {:x 0 :y  0} :north)
+                   (robot-simulator/simulate "LAAARALA"))]
     (is (= {:x -4 :y 1} (:coordinates clutz)))))
 
-(deftest simulate-sphero
+(deftest simulate-sphero-bearing
   (let [sphero (->> (robot-simulator/robot {:x 2 :y -7} :east)
                     (robot-simulator/simulate "RRAAAAALA"))]
-    (is (= :south (:bearing sphero)))
+    (is (= :south (:bearing sphero)))))
+
+(deftest simulate-sphero-coords
+  (let [sphero (->> (robot-simulator/robot {:x 2 :y -7} :east)
+                    (robot-simulator/simulate "RRAAAAALA"))]
     (is (= {:x -3 :y -8} (:coordinates sphero)))))
 
-(deftest simulate-roomba
+(deftest simulate-roomba-bearing
   (let [roomba (->> (robot-simulator/robot {:x 8 :y  4} :south)
                     (robot-simulator/simulate "LAAARRRALLLL"))]
-    (is (= :north (:bearing roomba)))
+    (is (= :north (:bearing roomba)))))
+
+(deftest simulate-roomba-coords
+  (let [roomba (->> (robot-simulator/robot {:x 8 :y  4} :south)
+                    (robot-simulator/simulate "LAAARRRALLLL"))]
     (is (= {:x 11 :y 5} (:coordinates roomba)))))

--- a/exercises/practice/rotational-cipher/test/rotational_cipher_test.clj
+++ b/exercises/practice/rotational-cipher/test/rotational_cipher_test.clj
@@ -2,46 +2,45 @@
   (:require  [clojure.test :refer [deftest is testing]]
              rotational-cipher))
 
-(deftest rotational-cipher-test
-  (testing "rotate a by 1"
-    (is (= (rotational-cipher/rotate "a" 1) "b")))
+(deftest rotate-a-by-1
+  (is (= (rotational-cipher/rotate "a" 1) "b")))
 
-  (testing "rotate a by 26, same output as input"
-    (is (= (rotational-cipher/rotate "a" 26) "a")))
+(deftest rotate-a-by-26-same-output
+  (is (= (rotational-cipher/rotate "a" 26) "a")))
 
-  (testing "rotate a by 0, same output as input"
-    (is (= (rotational-cipher/rotate "a" 0) "a")))
+(deftest rotate-a-by-0-same-output
+  (is (= (rotational-cipher/rotate "a" 0) "a")))
 
-  (testing "rotate m by 13"
-    (is (= (rotational-cipher/rotate "m" 13) "z")))
+(deftest rotate-m-by-13
+  (is (= (rotational-cipher/rotate "m" 13) "z")))
 
-  (testing "rotate n by 13 with wrap around alphabet"
-    (is (= (rotational-cipher/rotate "n" 13) "a")))
+(deftest rotate-n-by-13-with-wrap
+  (is (= (rotational-cipher/rotate "n" 13) "a")))
 
-  (testing "rotate capital letters"
-    (is (= (rotational-cipher/rotate "OMG" 5) "TRL")))
+(deftest rotate-capital-letters
+  (is (= (rotational-cipher/rotate "OMG" 5) "TRL")))
 
-  (testing "rotate spaces"
-    (is (= (rotational-cipher/rotate "O M G" 5) "T R L")))
+(deftest rotate-spaces
+  (is (= (rotational-cipher/rotate "O M G" 5) "T R L")))
 
-  (testing "rotate numbers"
-    (is (= (rotational-cipher/rotate "Testing 1 2 3 testing" 4) "Xiwxmrk 1 2 3 xiwxmrk")))
+(deftest rotate-numbers
+  (is (= (rotational-cipher/rotate "Testing 1 2 3 testing" 4) "Xiwxmrk 1 2 3 xiwxmrk")))
 
-  (testing "rotate punctuation"
-    (is (= (rotational-cipher/rotate "Let's eat, Grandma!" 21) "Gzo'n zvo, Bmviyhv!")))
+(deftest rotate-punctuation
+  (is (= (rotational-cipher/rotate "Let's eat, Grandma!" 21) "Gzo'n zvo, Bmviyhv!")))
 
-  (testing "rotate in the opposite direction"
-    (is (= (rotational-cipher/rotate "b" -1) "a")))
+(deftest rotate-opposite-direction
+  (is (= (rotational-cipher/rotate "b" -1) "a")))
 
-  (testing "rotate in the opposite direction past first letter"
-    (is (= (rotational-cipher/rotate "B" -2) "Z")))
+(deftest rotate-opposite-past-first-letter
+  (is (= (rotational-cipher/rotate "B" -2) "Z")))
 
-  (testing "rotate in the opposite direction past letter count"
-    (is (= (rotational-cipher/rotate "B" -28) "Z")))
+(deftest rotate-opposite-past-letter-count
+  (is (= (rotational-cipher/rotate "B" -28) "Z")))
 
-  (testing "rotate forward then backwards the same number of steps"
-    (is (=  (rotational-cipher/rotate
-             (rotational-cipher/rotate "B" 28) -28) "B")))
+(deftest rotate-forward-then-backwards-same-number-of-steps
+  (is (=  (rotational-cipher/rotate
+           (rotational-cipher/rotate "B" 28) -28) "B")))
 
-  (testing "rotate all letters"
-    (is (= (rotational-cipher/rotate "The quick brown fox jumps over the lazy dog." 13) "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."))))
+(deftest rotate-all-letters
+  (is (= (rotational-cipher/rotate "The quick brown fox jumps over the lazy dog." 13) "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.")))

--- a/exercises/practice/sublist/test/sublist_test.clj
+++ b/exercises/practice/sublist/test/sublist_test.clj
@@ -2,38 +2,53 @@
   (:require [clojure.test :refer [deftest is testing]]
             sublist))
 
-(deftest sublist-tests
-  (testing "empty lists"
+(deftest empty-lists-test
     (is (= :equal (sublist/classify [] []))))
-  (testing "empty list within non empty list"
+
+(deftest empty-list-within-non-empty-list-test
     (is (= :sublist (sublist/classify [] [1 2 3]))))
-  (testing "non empty list contains empty list"
+
+(deftest non-empty-list-contains-empty-list-test
     (is (= :superlist (sublist/classify [1 2 3] []))))
-  (testing "list equals itself"
+
+(deftest list-equals-itself-test
     (is (= :equal (sublist/classify [1 2 3] [1 2 3]))))
-  (testing "different lists"
+
+(deftest different-lists
     (is (= :unequal (sublist/classify [1 2 3] [2 3 4]))))
-  (testing "false start"
+
+(deftest false-start
     (is (= :sublist (sublist/classify [1 2 5] [0 1 2 3 1 2 5 6]))))
-  (testing "consecutive"
+
+(deftest consecutive
     (is (= :sublist (sublist/classify [1 1 2] [0 1 1 1 2 1 2]))))
-  (testing "sublist at start"
+
+(deftest sublist-at-start
     (is (= :sublist (sublist/classify [0 1 2] [0 1 2 3 4 5]))))
-  (testing "sublist in middle"
+
+(deftest sublist-in-middle
     (is (= :sublist (sublist/classify [2 3 4] [0 1 2 3 4 5]))))
-  (testing "sublist at end"
+
+(deftest sublist-at-end
     (is (= :sublist (sublist/classify [3 4 5] [0 1 2 3 4 5]))))
-  (testing "at start of superlist"
+
+(deftest at-start-of-superlist
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [0 1 2]))))
-  (testing "in middle of superlist"
+
+(deftest in-middle-of-superlist
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [2 3]))))
-  (testing "at end of superlist"
+
+(deftest at-end-of-superlist
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [3 4 5]))))
-  (testing "first list missing element from second list"
+
+(deftest first-list-missing-element-from-second-list
     (is (= :unequal (sublist/classify [1 3] [1 2 3]))))
-  (testing "second list missing element from first list"
+
+(deftest second-list-missing-element-from-first-list
     (is (= :unequal (sublist/classify [1 2 3] [1 3]))))
-  (testing "order matters to a list"
+
+(deftest order-matters-to-a-list
     (is (= :unequal (sublist/classify [1 2 3] [3 2 1]))))
-  (testing "same digits but different numbers"
-    (is (= :unequal (sublist/classify [1 0 1] [10 1])))))
+
+(deftest same-digits-but-different-numbers
+    (is (= :unequal (sublist/classify [1 0 1] [10 1]))))

--- a/exercises/practice/triangle/test/triangle_test.clj
+++ b/exercises/practice/triangle/test/triangle_test.clj
@@ -2,50 +2,59 @@
   (:require [clojure.test :refer [deftest is testing]]
             triangle))
 
-(deftest equilateral
-  (testing "equilateral triangle"
-    (testing "all sides are equal"
+(deftest equilateral-all-sides-equal
       (is (true? (triangle/equilateral? 2 2 2))))
-    (testing "any side is unequal"
+
+(deftest equilateral-any-side-is-unequal
       (is (false? (triangle/equilateral? 2 3 2))))
-    (testing "no sides are equal"
+
+(deftest equilateral-no sides are equal
       (is (false? (triangle/equilateral? 5 4 6))))
-    (testing "all zero sides is not a triangle"
+
+(deftest equilateral-all-zero-sides
       (is (false? (triangle/equilateral? 0 0 0))))
-    (testing "sides may be floats"
-      (is (true? (triangle/equilateral? 0.5 0.5 0.5))))))
 
+(deftest equilateral-sides-may-be-floats
+      (is (true? (triangle/equilateral? 0.5 0.5 0.5))))
 
-(deftest isosceles
-  (testing "isosceles triangle"
-    (testing "last two sides are equal"
+(deftest isosceles-last-two-sides-equal
       (is (true? (triangle/isosceles? 3 4 4))))
-    (testing "first two sides are equal"
-      (is (true? (triangle/isosceles? 4 4 3))))
-    (testing "first and last sides are equal"
-      (is (true? (triangle/isosceles? 4 3 4))))
-    (testing "equilateral triangles are also isosceles"
-      (is (true? (triangle/isosceles? 4 4 4))))
-    (testing "no sides are equal"
-      (is (false? (triangle/isosceles? 2 3 4))))
-    (testing "first triangle inequality violation"
-      (is (false? (triangle/isosceles? 1 1 3))))
-    (testing "second triangle inequality violation"
-      (is (false? (triangle/isosceles? 1 3 1))))
-    (testing "third triangle inequality violation"
-      (is (false? (triangle/isosceles? 3 1 1))))
-    (testing "sides may be floats"
-      (is (true? (triangle/isosceles? 0.5 0.4 0.5))))))
 
-(deftest scalene
-  (testing "scalene triangle"
-    (testing "no sides are equal"
+(deftest isosceles-first-two-sides-equal
+      (is (true? (triangle/isosceles? 4 4 3))))
+
+(deftest isosceles-first-last-sides-equal
+      (is (true? (triangle/isosceles? 4 3 4))))
+
+(deftest isosceles-equilateral-triangles-also-isosceles
+      (is (true? (triangle/isosceles? 4 4 4))))
+
+(deftest isosceles-no-sides-equal
+      (is (false? (triangle/isosceles? 2 3 4))))
+
+(deftest isosceles-first-triangle-inequality-violation
+      (is (false? (triangle/isosceles? 1 1 3))))
+
+(deftest isosceles-second-triangle-inequality-violation
+      (is (false? (triangle/isosceles? 1 3 1))))
+
+(deftest isosceles-third-triangle-inequality-violation
+      (is (false? (triangle/isosceles? 3 1 1))))
+
+(deftest isosceles-sides-may-be-floats
+      (is (true? (triangle/isosceles? 0.5 0.4 0.5))))
+
+(deftest scalene-no-sides-are-equal
       (is (true? (triangle/scalene? 5 4 6))))
-    (testing "all sides are equal"
+
+(deftest scalene-all-sides-equal
       (is (false? (triangle/scalene? 4 4 4))))
-    (testing "two sides are equal"
+
+(deftest scalene-two-sides-equal
       (is (false? (triangle/scalene? 4 4 3))))
-    (testing "may not violate triangle inequality"
+
+(deftest scalene-may-not-violate-triangle-inequality
       (is (false? (triangle/scalene? 7 3 2))))
-    (testing "sides may be floats"
-      (is (true? (triangle/scalene? 0.5 0.4 0.6))))))
+
+(deftest scalene-sides-may-be-floats
+      (is (true? (triangle/scalene? 0.5 0.4 0.6))))


### PR DESCRIPTION
As a quick fix for the test runner not handling some tests properly (see https://github.com/exercism/clojure/issues/420 and https://github.com/exercism/clojure/issues/421), I decided to simply rewrite the tests to suit the runner. Every `is` assertion in this PR has been wrapped within its own `deftest` so it will be properly reported on the website.

The real fix is this: https://github.com/exercism/clojure-test-runner/issues/22 but it's taking a bit longer and this will at least get the user experience working right.