### PR TITLE
Fix typos in spec

### DIFF
--- a/exercises/practice/triangle/test/triangle_test.clj
+++ b/exercises/practice/triangle/test/triangle_test.clj
@@ -8,7 +8,7 @@
 (deftest equilateral-any-side-is-unequal
       (is (false? (triangle/equilateral? 2 3 2))))
 
-(deftest equilateral-no sides are equal
+(deftest equilateral-no-sides-are-equal
       (is (false? (triangle/equilateral? 5 4 6))))
 
 (deftest equilateral-all-zero-sides


### PR DESCRIPTION
A few dashes were missing in a test name, causing the specs to error out. This PR fixes that.