### PR TITLE
Correct BigDecimal arithmetic

### DIFF
--- a/config.json
+++ b/config.json
@@ -129,6 +129,22 @@
           "lists", "vectors", "strings"
         ],
         "status": "beta"
+      },
+      {
+        "slug": "international-calling-connoisseur",
+        "name": "International Calling Connoisseur",
+        "uuid": "60d4333d-b40a-4ce2-858d-0e003356f41a",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "squeaky-clean",
+        "name": "Squeaky Clean",
+        "uuid": "3af5b219-d751-4243-89f7-c8f05216f534",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
       }
     ],
     "practice": [

--- a/exercises/concept/interest-is-interesting/.meta/exemplar.clj
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.clj
@@ -7,7 +7,7 @@
     (< balance 5000.0M) 1.621
     :else 2.475))
 
-(defn annual-yield [balance]
+(defn- annual-yield [balance]
   (let [multiplier (/ (interest-rate balance)
                       100.0M)]
     (* balance multiplier)))

--- a/exercises/concept/interest-is-interesting/.meta/exemplar.clj
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.clj
@@ -10,7 +10,7 @@
 (defn- annual-yield [balance]
   (let [multiplier (/ (interest-rate balance)
                       100.0M)]
-    (* balance multiplier)))
+    (* (Math/abs balance) multiplier)))
 
 (defn annual-balance-update [balance]
   (bigdec (+ balance (annual-yield balance))))

--- a/exercises/concept/interest-is-interesting/.meta/exemplar.clj
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.clj
@@ -10,7 +10,7 @@
 (defn- annual-yield [balance]
   (let [multiplier (/ (interest-rate balance)
                       100.0M)]
-    (* (Math/abs balance) multiplier)))
+    (* (if (neg? balance) (- balance) balance) multiplier)))
 
 (defn annual-balance-update [balance]
   (bigdec (+ balance (annual-yield balance))))

--- a/exercises/concept/interest-is-interesting/.meta/exemplar.clj
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.clj
@@ -8,12 +8,12 @@
     :else 2.475))
 
 (defn- annual-yield [balance]
-  (let [multiplier (/ (interest-rate balance)
-                      100.0M)]
+  (let [multiplier (bigdec (/ (interest-rate balance)
+                              100))]
     (* (if (neg? balance) (- balance) balance) multiplier)))
 
 (defn annual-balance-update [balance]
-  (bigdec (+ balance (annual-yield balance))))
+  (+ balance (annual-yield balance)))
 
 (defn amount-to-donate [balance tax-free-percentage]
   (if (> balance 0.0M)

--- a/exercises/concept/interest-is-interesting/src/interest_is_interesting.clj
+++ b/exercises/concept/interest-is-interesting/src/interest_is_interesting.clj
@@ -5,11 +5,6 @@
   [balance]
   )
 
-(defn annual-yield
-  "TODO: add docstring"
-  [balance]
-  )
-
 (defn annual-balance-update
   "TODO: add docstring"
   [balance]

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -54,13 +54,13 @@
   (is (= 1016.210101621M (interest-is-interesting/annual-balance-update 1000.0001M))))
 
 (deftest annual-balance-update-huge-positive-balance-test
-  (is (= 920352587.267443M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))
+  (is (= 920352587.26744292868451875M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))
 
 (deftest annual-balance-update-small-negative-balance-test
-  (is (= -0.11904801M (interest-is-interesting/annual-balance-update -0.123M))))
+  (is (= -0.12695199M (interest-is-interesting/annual-balance-update -0.123M))))
 
 (deftest annual-balance-update-large-negative-balance-test
-  (is (= -148049.49025797M (interest-is-interesting/annual-balance-update -152964.231M))))
+  (is (= -157878.97174203M (interest-is-interesting/annual-balance-update -152964.231M))))
 
 (deftest amount-to-donate-empty-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate 0.0M 2.0))))

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -51,7 +51,7 @@
   (is (= 1016.210000M (interest-is-interesting/annual-balance-update 1000.0M))))
 
 (deftest annual-balance-update-large-positive-balance-test
-  (is (= 1016.2101016209999M (interest-is-interesting/annual-balance-update 1000.0001M))))
+  (is (= 1016.210101621M (interest-is-interesting/annual-balance-update 1000.0001M))))
 
 (deftest annual-balance-update-huge-positive-balance-test
   (is (= 920352587.267443M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))


### PR DESCRIPTION
Fixes: #428 and #430. When porting this exercise I noticed some arithmetic discrepancies and wrongly assumed they were due to minor differences in the way the JVM and CLR handle decimals. Turns out I was doing something wrong, and fortunately this was brought to my attention so I could fix it before this exercise confuses many more people :P