### PR TITLE
docs(elyses): remove misleading instruction

### DIFF
--- a/exercises/concept/elyses-destructured-enchantments/.docs/instructions.md
+++ b/exercises/concept/elyses-destructured-enchantments/.docs/instructions.md
@@ -28,7 +28,7 @@ Elyse performs sleight of hand, and summons the second card in the deck, without
 
 ## 3. Swap the first two cards
 
-Elyse will make the top two cards of the deck switch places. She doesn't need to call a single function.
+Elyse will make the top two cards of the deck switch places.
 
 ```clojure
 (def deck [10 7 3 8 5])


### PR DESCRIPTION
Part 3, "Swap the first two cards", can't be solved with destructuring alone, yet the instructions suggest otherwise.

If someone is up for the challenge, please try it, but even @porkostomus (author) used `vec` and `conj` :) 
https://exercism.org/tracks/clojure/exercises/elyses-destructured-enchantments/solutions/porkostomus