### PR TITLE
Typo: `abouts` > `about`

### DIFF
--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Learn abouts lists by keeping track of the programming languages you want to learn",
+  "blurb": "Learn about lists by keeping track of the programming languages you want to learn",
   "authors": ["bemself"],
   "contributors": [
     "porkostomus",


### PR DESCRIPTION
Perhaps the first contribution of many. And perhaps the only one that is only about one character :). 

Typo: `abouts` should be `about`. #459  

I'm assuming pull requests go to `main`. If not, I'd love to learn otherwise.