### PR TITLE
remove dev workflow

### DIFF
--- a/test.clj
+++ b/test.clj
@@ -6,20 +6,9 @@
  '[clojure.java.shell :as shell]
  '[clojure.java.io :as io])
 
-(defn clean-path [path]
-  (if (str/ends-with? path "/")
-    path
-    (str path "/")))
+(def root "/github/workspace/main/")
 
-(def root 
-  (clean-path (if (.exists (io/file (str (clean-path (first *command-line-args*)) "config.json")))
-                (first *command-line-args*)
-                "/github/workspace/main/")))
-
-(def test-runner-dir 
-  (clean-path (if (.exists (io/file (str (clean-path (first *command-line-args*)) "test-runner.clj")))
-                (first *command-line-args*)
-                  "/github/workspace/clojure-test-runner/")))
+(def test-runner-dir "/github/workspace/clojure-test-runner/")
 
 (defn- ->snake_case [s] (str/replace s \- \_))
 


### PR DESCRIPTION
CI has been failing since features were added to the test runner and I believe it was related to a conditional development workflow in `test.clj` that doesn't belong there anyway. It was remaining from when I developed the CI script and it was actually preventing a proper integration test with the `clojure-test-runner` repo as was intended. This change simply hardcodes the `root` and `test-runner-dir` locations to where they are in prod.