### PR TITLE
Add hyphens to fix hints

### DIFF
--- a/exercises/concept/bird-watcher/.docs/hints.md
+++ b/exercises/concept/bird-watcher/.docs/hints.md
@@ -2,41 +2,41 @@
 
 ## Check what the counts were last week
 
-[Vectors][vectors] are represented in Clojure using square brackets (`[ ]`)
+- [Vectors][vectors] are represented in Clojure using square brackets (`[ ]`)
 
 ## Check how many birds visited today
 
-The [`last`][last] function can be used to return the last item in a sequential collection.
+- The [`last`][last] function can be used to return the last item in a sequential collection.
 
 ## Increment today's count
 
-The [`update`][update] function can be used to return a new vector with a different element at a given index.
+- The [`update`][update] function can be used to return a new vector with a different element at a given index.
 
-The [`count`][count] function can be used to find the length of the vector.
+- The [`count`][count] function can be used to find the length of the vector.
 
-The [`inc`][inc] and [`dec`][dec] functions can be used to increment and decrement integer values.
+- The [`inc`][inc] and [`dec`][dec] functions can be used to increment and decrement integer values.
 
 ## Check if there was a day with no visiting birds
 
-The [`every?`][every?] function can be used to check if all items in a collection satisfy a given predicate.
+- The [`every?`][every?] function can be used to check if all items in a collection satisfy a given predicate.
 
-The [`pos?`][pos?] predicate returns true if a number is greater than zero.
+- The [`pos?`][pos?] predicate returns true if a number is greater than zero.
 
-The [`not`][not] function returns true if an expression evaluates to logical false.
+- The [`not`][not] function returns true if an expression evaluates to logical false.
 
 ## Calculate the number of visiting birds for the first number of days
 
-The [`take`][take] function can be used return a sequence of the first n items in a collection.
+- The [`take`][take] function can be used return a sequence of the first n items in a collection.
 
-The [`reduce`][reduce] function can be used to add a collection of values together.
+- The [`reduce`][reduce] function can be used to add a collection of values together.
 
 ## Calculate the number of busy days
 
-The [`filter`][filter] higher-order function can be used to return a sequence of items in a collection which satisfy a given predicate.
+- The [`filter`][filter] higher-order function can be used to return a sequence of items in a collection which satisfy a given predicate.
 
 ## Check for odd week
 
-The [`=`][equality] function can be used to test equality.
+- The [`=`][equality] function can be used to test equality.
 
 [count]: https://clojuredocs.org/clojure.core/count
 [dec]: https://clojuredocs.org/clojure.core/dec

--- a/exercises/concept/interest-is-interesting/.docs/hints.md
+++ b/exercises/concept/interest-is-interesting/.docs/hints.md
@@ -2,15 +2,15 @@
 
 ## Calculate the interest rate
 
-You can refer back to the [conditionals][conditionals] concept if you need to remember how to return values based on an input value.
+- You can refer back to the [conditionals][conditionals] concept if you need to remember how to return values based on an input value.
 
 ## Calculate the annual balance update
 
-The [`bigdec`][bigdec] function can be used to coerce a number to a [BigDecimal][bigdecimal].
+- The [`bigdec`][bigdec] function can be used to coerce a number to a [BigDecimal][bigdecimal].
 
 ## Calculate how much money to donate
 
-The [`int`][int] function can be used to coerce a number to an integer.
+- The [`int`][int] function can be used to coerce a number to an integer.
 
 [bigdec]: https://clojuredocs.org/clojure.core/bigdec
 [bigdecimal]: https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html

--- a/exercises/concept/log-levels/.docs/hints.md
+++ b/exercises/concept/log-levels/.docs/hints.md
@@ -11,7 +11,7 @@
 
 ## 2. Get log level from a log line
 
-- A `string` can be converted to a lowercase using [`lowercase`][lowercase].
+- A `string` can be converted to lowercase using [`lowercase`][lowercase].
 
 ## 3. Reformat a log line
 


### PR DESCRIPTION
Hints were not being rendered because I forgot to add hyphens. Apparently the spec requires them to be an unordered list.