### PR TITLE
Improves `nth-prime` scaffold

### DIFF
--- a/exercises/practice/nth-prime/src/nth_prime.clj
+++ b/exercises/practice/nth-prime/src/nth_prime.clj
@@ -1,5 +1,7 @@
 (ns nth-prime)
 
-(defn nth-prime [] ;; <- arglist goes here
+(defn nth-prime 
+  "Returns the prime number in the nth position."
+  [n] ;; <- arglist goes here
   ;; your code goes here
   )


### PR DESCRIPTION
Not sure if this one specifically wants the missing arg to be included by the user, but until this exercise, all had the args filled, so I think maintaining consistency should be desired here.