### PR TITLE
test: fix list-add test

### DIFF
--- a/exercises/concept/tracks-on-tracks-on-tracks/.docs/instructions.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.docs/instructions.md
@@ -18,7 +18,7 @@ Before you can add languages, you'll need to start by creating a new list. Defin
 As you explore Exercism and find languages you want to learn, you'll need to be able to add them to your list. Define a function to add a new language the beginning of your list.
 
 ```clojure
-(add-language "JavaScript" '("Clojurescript"))
+(add-language '("Clojurescript") "JavaScript")
 ;; => '("JavaScript" "Clojurescript")
 ```
 


### PR DESCRIPTION
Use thread-last in list-add test to match Task 2
example:

Task 2 Add a new language to the list example:
```clojure
(add-language "JavaScript" '("Clojurescript"))
;; => '("JavaScript" "Clojurescript")
```

Fails Test 2 list-add-test
<img width="582" alt="Screen Shot 2022-06-08 at 6 51 34 AM" src="https://user-images.githubusercontent.com/16216104/172489251-5baa93d0-f6d0-4eb1-b065-4199e020f00a.png">

Thread-first would work if the parameters were switched. What is the intended argument order?

```clojure

;; Current test depends on this parameter order
(defn add-language [lang-list lang]
  (conj lang-list lang))

;; Example gives this parameter order
(defn add-language [lang lang-list]
  (conj lang-list lang))
```