### PR TITLE
Fix URL for clojure-docs page about strings

### DIFF
--- a/concepts/strings/links.json
+++ b/concepts/strings/links.json
@@ -1,6 +1,6 @@
 [
     {
-      "url": "http://clojure-doc.org/articles/cookbooks/strings.html",
+      "url": "https://clojure-doc.org/articles/cookbooks/strings/",
       "description": "Clojure Docs: Strings"
     }
   ]


### PR DESCRIPTION
The old URL (http://clojure-doc.org/articles/cookbooks/strings.html) returns a 404. This updates the URL to the current location of the docs.