### PR TITLE
Interest is Interesting exemplar: Use Java's built-in Math.abs instead of if block

### DIFF
--- a/exercises/concept/interest-is-interesting/.meta/exemplar.clj
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.clj
@@ -10,7 +10,7 @@
 (defn- annual-yield [balance]
   (let [multiplier (bigdec (/ (interest-rate balance)
                               100))]
-    (* (if (neg? balance) (- balance) balance) multiplier)))
+    (* (Math/abs balance) multiplier)))
 
 (defn annual-balance-update [balance]
   (+ balance (annual-yield balance)))


### PR DESCRIPTION
It's not a good idea to roll your own absolute value logic when the standard library has a method for that already