### PR TITLE
Add task-test metadata v2

### DIFF
--- a/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
+++ b/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
@@ -2,122 +2,122 @@
   (:require [clojure.test :refer [deftest testing is]]
             annalyns-infiltration))
 
-(deftest fast-attack-awake-test
+(deftest ^:task1 fast-attack-awake-test
   (testing "Fast attack if knight is awake"
     (is (= false (annalyns-infiltration/can-fast-attack? true)))))
 
-(deftest fast-attack-asleep-test
+(deftest ^:task1 fast-attack-asleep-test
   (testing "Fast attack if knight is sleeping"
     (is (= true (annalyns-infiltration/can-fast-attack? false)))))
 
-(deftest spy-everyone-sleeping-test
+(deftest ^:task2 spy-everyone-sleeping-test
   (testing "Cannot spy if everyone is sleeping"
     (is (= false (annalyns-infiltration/can-spy? false false false)))))
 
-(deftest spy-but-knight-sleeping-test
+(deftest ^:task2 spy-but-knight-sleeping-test
   (testing "Can spy if everyone but knight is sleeping"
     (is (= true (annalyns-infiltration/can-spy? true false false)))))
 
-(deftest spy-but-archer-sleeping-test
+(deftest ^:task2 spy-but-archer-sleeping-test
   (testing "Can spy if everyone but archer is sleeping"
     (is (= true (annalyns-infiltration/can-spy? false true false)))))
 
-(deftest spy-but-prisoner-sleeping-test
+(deftest ^:task2 spy-but-prisoner-sleeping-test
   (testing "Can spy if everyone but prisoner is sleeping"
     (is (= true (annalyns-infiltration/can-spy? false false true)))))
 
-(deftest spy-only-knight-sleeping-test
+(deftest ^:task2 spy-only-knight-sleeping-test
   (testing "Can spy if only knight is sleeping"
     (is (= true (annalyns-infiltration/can-spy? false true true)))))
 
-(deftest spy-only-archer-sleeping-test
+(deftest ^:task2 spy-only-archer-sleeping-test
   (testing "Can spy if only archer is sleeping"
     (is (= true (annalyns-infiltration/can-spy? true false true)))))
 
-(deftest spy-only-prisoner-sleeping-test
+(deftest ^:task2 spy-only-prisoner-sleeping-test
   (testing "Can spy if only prisoner is sleeping"
     (is (= true (annalyns-infiltration/can-spy? true true false)))))
 
-(deftest spy-everyone-awake-test
+(deftest ^:task2 spy-everyone-awake-test
   (testing "Can spy if everyone is awake"
     (is (= true (annalyns-infiltration/can-spy? true true true)))))
 
-(deftest signal-prisoner-archer-sleeping-prisoner-awake-test
+(deftest ^:task3 signal-prisoner-archer-sleeping-prisoner-awake-test
   (testing "Can signal prisoner if archer is sleeping and prisoner is awake"
     (is (= true (annalyns-infiltration/can-signal-prisoner? false true)))))
 
-(deftest signal-prisoner-archer-awake-prisoner-sleeping-test
+(deftest ^:task3 signal-prisoner-archer-awake-prisoner-sleeping-test
   (testing "Cannot signal prisoner if archer is awake and prisoner is sleeping"
       (is (= false (annalyns-infiltration/can-signal-prisoner? true false)))))
 
-(deftest signal-prisoner-both-sleeping-test
+(deftest ^:task3 signal-prisoner-both-sleeping-test
   (testing "Cannot signal prisoner if archer and prisoner are both sleeping"
       (is (= false (annalyns-infiltration/can-signal-prisoner? false false)))))
 
-(deftest signal-prisoner-both-awake-test
+(deftest ^:task3 signal-prisoner-both-awake-test
   (testing "Cannot signal prisoner if archer and prisoner are both awake"
       (is (= false (annalyns-infiltration/can-signal-prisoner? true true)))))
 
-(deftest release-prisoner-everyone-awake-dog-present-test
+(deftest ^:task4 release-prisoner-everyone-awake-dog-present-test
   (testing "Cannot release prisoner if everyone is awake and pet dog is present"
       (is (= false (annalyns-infiltration/can-free-prisoner? true true true true)))))
 
-(deftest release-prisoner-everyone-awake-dog-absent-test
+(deftest ^:task4 release-prisoner-everyone-awake-dog-absent-test
     (testing "Cannot release prisoner if everyone is awake and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? true true true false)))))
     
-(deftest release-prisoner-everyone-asleep-dog-absent-test
+(deftest ^:task4 release-prisoner-everyone-asleep-dog-absent-test
     (testing "Cannot release prisoner if everyone is asleep and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? false false false false)))))
 
-(deftest release-prisoner-archer-awake-dog-present-test
+(deftest ^:task4 release-prisoner-archer-awake-dog-present-test
     (testing "Cannot release prisoner if only archer is awake and pet dog is present"
       (is (= false (annalyns-infiltration/can-free-prisoner? false true false true)))))
 
-(deftest release-prisoner-archer-awake-dog-absent-test
+(deftest ^:task4 release-prisoner-archer-awake-dog-absent-test
     (testing "Cannot release prisoner if only archer is awake and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? false true false false)))))
 
-(deftest release-prisoner-knight-awake-dog-absent-test
+(deftest ^:task4 release-prisoner-knight-awake-dog-absent-test
     (testing "Cannot release prisoner if only knight is awake and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? true false false false)))))
 
-(deftest release-prisoner-knight-awake-dog-present-test
+(deftest ^:task4 release-prisoner-knight-awake-dog-present-test
     (testing "Cannot release prisoner if only knight is asleep and pet dog is present"
       (is (= false (annalyns-infiltration/can-free-prisoner? false true true true)))))
 
-(deftest release-prisoner-knight-asleep-dog-absent-test
+(deftest ^:task4 release-prisoner-knight-asleep-dog-absent-test
     (testing "Cannot release prisoner if only knight is asleep and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? false true true false)))))
 
-(deftest release-prisoner-archer-asleep-dog-absent-test
+(deftest ^:task4 release-prisoner-archer-asleep-dog-absent-test
     (testing "Cannot release prisoner if only archer is asleep and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? true false true false)))))
 
-(deftest release-prisoner-prisoner-asleep-dog-present-test
+(deftest ^:task4 release-prisoner-prisoner-asleep-dog-present-test
     (testing "Cannot release prisoner if only prisoner is asleep and pet dog is present"
       (is (= false (annalyns-infiltration/can-free-prisoner? true true false true)))))
 
-(deftest release-prisoner-prisoner-asleep-dog-absent-test
+(deftest ^:task4 release-prisoner-prisoner-asleep-dog-absent-test
     (testing "Cannot release prisoner if only prisoner is asleep and pet dog is absent"
       (is (= false (annalyns-infiltration/can-free-prisoner? true true false false)))))
 
-(deftest release-prisoner-everyone-asleep-dog-present-test
+(deftest ^:task4 release-prisoner-everyone-asleep-dog-present-test
     (testing "Can release prisoner if everyone is asleep and pet dog is present"
       (is (= true (annalyns-infiltration/can-free-prisoner? false false false true)))))
 
-(deftest release-prisoner-prisoner-awake-dog-present-test
+(deftest ^:task4 release-prisoner-prisoner-awake-dog-present-test
     (testing "Can release prisoner if only prisoner is awake and pet dog is present"
       (is (= true (annalyns-infiltration/can-free-prisoner? false false true true)))))
 
-(deftest release-prisoner-prisoner-awake-dog-absent-test
+(deftest ^:task4 release-prisoner-prisoner-awake-dog-absent-test
     (testing "Can release prisoner if only prisoner is awake and pet dog is absent"
       (is (= true (annalyns-infiltration/can-free-prisoner? false false true false)))))
 
-(deftest release-prisoner-knight-awake-dog-present-test
+(deftest ^:task4 release-prisoner-knight-awake-dog-present-test
     (testing "Can release prisoner if only knight is awake and pet dog is present"
       (is (= true (annalyns-infiltration/can-free-prisoner? true false false true)))))
 
-(deftest release-prisoner-archer-asleep-dog-present-test
+(deftest ^:task4 release-prisoner-archer-asleep-dog-present-test
     (testing "Can release prisoner if only archer is asleep and pet dog is present"
       (is (= true (annalyns-infiltration/can-free-prisoner? true false true true)))))

--- a/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
+++ b/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
@@ -1,123 +1,123 @@
 (ns annalyns-infiltration-test
-  (:require [clojure.test :refer [deftest testing is]]
-            annalyns-infiltration))
+  (:require annalyns-infiltration
+            [clojure.test :refer [deftest is testing]]))
 
-(deftest ^:task1 fast-attack-awake-test
+(deftest ^{:task 1} fast-attack-awake-test
   (testing "Fast attack if knight is awake"
     (is (= false (annalyns-infiltration/can-fast-attack? true)))))
 
-(deftest ^:task1 fast-attack-asleep-test
+(deftest ^{:task 1} fast-attack-asleep-test
   (testing "Fast attack if knight is sleeping"
     (is (= true (annalyns-infiltration/can-fast-attack? false)))))
 
-(deftest ^:task2 spy-everyone-sleeping-test
+(deftest ^{:task 2} spy-everyone-sleeping-test
   (testing "Cannot spy if everyone is sleeping"
     (is (= false (annalyns-infiltration/can-spy? false false false)))))
 
-(deftest ^:task2 spy-but-knight-sleeping-test
+(deftest ^{:task 2} spy-but-knight-sleeping-test
   (testing "Can spy if everyone but knight is sleeping"
     (is (= true (annalyns-infiltration/can-spy? true false false)))))
 
-(deftest ^:task2 spy-but-archer-sleeping-test
+(deftest ^{:task 2} spy-but-archer-sleeping-test
   (testing "Can spy if everyone but archer is sleeping"
     (is (= true (annalyns-infiltration/can-spy? false true false)))))
 
-(deftest ^:task2 spy-but-prisoner-sleeping-test
+(deftest ^{:task 2} spy-but-prisoner-sleeping-test
   (testing "Can spy if everyone but prisoner is sleeping"
     (is (= true (annalyns-infiltration/can-spy? false false true)))))
 
-(deftest ^:task2 spy-only-knight-sleeping-test
+(deftest ^{:task 2} spy-only-knight-sleeping-test
   (testing "Can spy if only knight is sleeping"
     (is (= true (annalyns-infiltration/can-spy? false true true)))))
 
-(deftest ^:task2 spy-only-archer-sleeping-test
+(deftest ^{:task 2} spy-only-archer-sleeping-test
   (testing "Can spy if only archer is sleeping"
     (is (= true (annalyns-infiltration/can-spy? true false true)))))
 
-(deftest ^:task2 spy-only-prisoner-sleeping-test
+(deftest ^{:task 2} spy-only-prisoner-sleeping-test
   (testing "Can spy if only prisoner is sleeping"
     (is (= true (annalyns-infiltration/can-spy? true true false)))))
 
-(deftest ^:task2 spy-everyone-awake-test
+(deftest ^{:task 2} spy-everyone-awake-test
   (testing "Can spy if everyone is awake"
     (is (= true (annalyns-infiltration/can-spy? true true true)))))
 
-(deftest ^:task3 signal-prisoner-archer-sleeping-prisoner-awake-test
+(deftest ^{:task 3} signal-prisoner-archer-sleeping-prisoner-awake-test
   (testing "Can signal prisoner if archer is sleeping and prisoner is awake"
     (is (= true (annalyns-infiltration/can-signal-prisoner? false true)))))
 
-(deftest ^:task3 signal-prisoner-archer-awake-prisoner-sleeping-test
+(deftest ^{:task 3} signal-prisoner-archer-awake-prisoner-sleeping-test
   (testing "Cannot signal prisoner if archer is awake and prisoner is sleeping"
-      (is (= false (annalyns-infiltration/can-signal-prisoner? true false)))))
+    (is (= false (annalyns-infiltration/can-signal-prisoner? true false)))))
 
-(deftest ^:task3 signal-prisoner-both-sleeping-test
+(deftest ^{:task 3} signal-prisoner-both-sleeping-test
   (testing "Cannot signal prisoner if archer and prisoner are both sleeping"
-      (is (= false (annalyns-infiltration/can-signal-prisoner? false false)))))
+    (is (= false (annalyns-infiltration/can-signal-prisoner? false false)))))
 
-(deftest ^:task3 signal-prisoner-both-awake-test
+(deftest ^{:task 3} signal-prisoner-both-awake-test
   (testing "Cannot signal prisoner if archer and prisoner are both awake"
-      (is (= false (annalyns-infiltration/can-signal-prisoner? true true)))))
+    (is (= false (annalyns-infiltration/can-signal-prisoner? true true)))))
 
-(deftest ^:task4 release-prisoner-everyone-awake-dog-present-test
+(deftest ^{:task 4} release-prisoner-everyone-awake-dog-present-test
   (testing "Cannot release prisoner if everyone is awake and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true true true)))))
+    (is (= false (annalyns-infiltration/can-free-prisoner? true true true true)))))
 
-(deftest ^:task4 release-prisoner-everyone-awake-dog-absent-test
-    (testing "Cannot release prisoner if everyone is awake and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true true false)))))
-    
-(deftest ^:task4 release-prisoner-everyone-asleep-dog-absent-test
-    (testing "Cannot release prisoner if everyone is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false false false false)))))
+(deftest ^{:task 4} release-prisoner-everyone-awake-dog-absent-test
+  (testing "Cannot release prisoner if everyone is awake and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? true true true false)))))
 
-(deftest ^:task4 release-prisoner-archer-awake-dog-present-test
-    (testing "Cannot release prisoner if only archer is awake and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true false true)))))
+(deftest ^{:task 4} release-prisoner-everyone-asleep-dog-absent-test
+  (testing "Cannot release prisoner if everyone is asleep and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? false false false false)))))
 
-(deftest ^:task4 release-prisoner-archer-awake-dog-absent-test
-    (testing "Cannot release prisoner if only archer is awake and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true false false)))))
+(deftest ^{:task 4} release-prisoner-archer-awake-dog-present-test
+  (testing "Cannot release prisoner if only archer is awake and pet dog is present"
+    (is (= false (annalyns-infiltration/can-free-prisoner? false true false true)))))
 
-(deftest ^:task4 release-prisoner-knight-awake-dog-absent-test
-    (testing "Cannot release prisoner if only knight is awake and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true false false false)))))
+(deftest ^{:task 4} release-prisoner-archer-awake-dog-absent-test
+  (testing "Cannot release prisoner if only archer is awake and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? false true false false)))))
 
-(deftest ^:task4 release-prisoner-knight-awake-dog-present-test
-    (testing "Cannot release prisoner if only knight is asleep and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true true true)))))
+(deftest ^{:task 4} release-prisoner-knight-awake-dog-absent-test
+  (testing "Cannot release prisoner if only knight is awake and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? true false false false)))))
 
-(deftest ^:task4 release-prisoner-knight-asleep-dog-absent-test
-    (testing "Cannot release prisoner if only knight is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? false true true false)))))
+(deftest ^{:task 4} release-prisoner-knight-awake-dog-present-test
+  (testing "Cannot release prisoner if only knight is asleep and pet dog is present"
+    (is (= false (annalyns-infiltration/can-free-prisoner? false true true true)))))
 
-(deftest ^:task4 release-prisoner-archer-asleep-dog-absent-test
-    (testing "Cannot release prisoner if only archer is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true false true false)))))
+(deftest ^{:task 4} release-prisoner-knight-asleep-dog-absent-test
+  (testing "Cannot release prisoner if only knight is asleep and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? false true true false)))))
 
-(deftest ^:task4 release-prisoner-prisoner-asleep-dog-present-test
-    (testing "Cannot release prisoner if only prisoner is asleep and pet dog is present"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true false true)))))
+(deftest ^{:task 4} release-prisoner-archer-asleep-dog-absent-test
+  (testing "Cannot release prisoner if only archer is asleep and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? true false true false)))))
 
-(deftest ^:task4 release-prisoner-prisoner-asleep-dog-absent-test
-    (testing "Cannot release prisoner if only prisoner is asleep and pet dog is absent"
-      (is (= false (annalyns-infiltration/can-free-prisoner? true true false false)))))
+(deftest ^{:task 4} release-prisoner-prisoner-asleep-dog-present-test
+  (testing "Cannot release prisoner if only prisoner is asleep and pet dog is present"
+    (is (= false (annalyns-infiltration/can-free-prisoner? true true false true)))))
 
-(deftest ^:task4 release-prisoner-everyone-asleep-dog-present-test
-    (testing "Can release prisoner if everyone is asleep and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? false false false true)))))
+(deftest ^{:task 4} release-prisoner-prisoner-asleep-dog-absent-test
+  (testing "Cannot release prisoner if only prisoner is asleep and pet dog is absent"
+    (is (= false (annalyns-infiltration/can-free-prisoner? true true false false)))))
 
-(deftest ^:task4 release-prisoner-prisoner-awake-dog-present-test
-    (testing "Can release prisoner if only prisoner is awake and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? false false true true)))))
+(deftest ^{:task 4} release-prisoner-everyone-asleep-dog-present-test
+  (testing "Can release prisoner if everyone is asleep and pet dog is present"
+    (is (= true (annalyns-infiltration/can-free-prisoner? false false false true)))))
 
-(deftest ^:task4 release-prisoner-prisoner-awake-dog-absent-test
-    (testing "Can release prisoner if only prisoner is awake and pet dog is absent"
-      (is (= true (annalyns-infiltration/can-free-prisoner? false false true false)))))
+(deftest ^{:task 4} release-prisoner-prisoner-awake-dog-present-test
+  (testing "Can release prisoner if only prisoner is awake and pet dog is present"
+    (is (= true (annalyns-infiltration/can-free-prisoner? false false true true)))))
 
-(deftest ^:task4 release-prisoner-knight-awake-dog-present-test
-    (testing "Can release prisoner if only knight is awake and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? true false false true)))))
+(deftest ^{:task 4} release-prisoner-prisoner-awake-dog-absent-test
+  (testing "Can release prisoner if only prisoner is awake and pet dog is absent"
+    (is (= true (annalyns-infiltration/can-free-prisoner? false false true false)))))
 
-(deftest ^:task4 release-prisoner-archer-asleep-dog-present-test
-    (testing "Can release prisoner if only archer is asleep and pet dog is present"
-      (is (= true (annalyns-infiltration/can-free-prisoner? true false true true)))))
+(deftest ^{:task 4} release-prisoner-knight-awake-dog-present-test
+  (testing "Can release prisoner if only knight is awake and pet dog is present"
+    (is (= true (annalyns-infiltration/can-free-prisoner? true false false true)))))
+
+(deftest ^{:task 4} release-prisoner-archer-asleep-dog-present-test
+  (testing "Can release prisoner if only archer is asleep and pet dog is present"
+    (is (= true (annalyns-infiltration/can-free-prisoner? true false true true)))))

--- a/exercises/concept/bird-watcher/test/bird_watcher_test.clj
+++ b/exercises/concept/bird-watcher/test/bird_watcher_test.clj
@@ -1,54 +1,54 @@
 (ns bird-watcher-test
-  (:require [clojure.test :refer [deftest testing is]]
-            bird-watcher))
+  (:require bird-watcher
+            [clojure.test :refer [deftest is testing]]))
 
-(deftest ^:task1 last-week-test
+(deftest ^{:task 1} last-week-test
   (is (= [0 2 5 3 7 8 4] bird-watcher/last-week)))
 
-(deftest ^:task2 today-disappointing-week-test
+(deftest ^{:task 2} today-disappointing-week-test
   (testing "Today's bird count of disappointing week"
     (is (= 0 (bird-watcher/today [0 0 2 0 0 1 0])))))
 
-(deftest ^:task2 today-busy-week-test
+(deftest ^{:task 2} today-busy-week-test
   (testing "Today's bird count of busy week"
     (is (= 10 (bird-watcher/today [8 8 9 5 4 7 10])))))
 
-(deftest ^:task3 increment-bird-no-visits-test
+(deftest ^{:task 3} increment-bird-no-visits-test
   (testing "Increment today's count with no previous visits"
     (is (= [6 5 5 11 2 5 1] (bird-watcher/inc-bird [6 5 5 11 2 5 0])))))
 
-(deftest ^:task3 increment-bird-multiple-visits-test
+(deftest ^{:task 3} increment-bird-multiple-visits-test
   (testing "Increment today's count with multiple previous visits"
     (is (= [5 2 4 2 4 5 8] (bird-watcher/inc-bird [5 2 4 2 4 5 7])))))
 
-(deftest ^:task4 day-without-birds-test
+(deftest ^{:task 4} day-without-birds-test
   (testing "Has day without birds with day without birds"
     (is (= true (bird-watcher/day-without-birds? [5 5 4 0 7 6 7])))))
 
-(deftest ^:task4 no-day-without-birds-test
+(deftest ^{:task 4} no-day-without-birds-test
   (testing "Has day without birds with no day without birds"
     (is (= false (bird-watcher/day-without-birds? [5 5 4 1 7 6 7])))))
 
-(deftest ^:task5 n-days-count-disappointing-week-test
+(deftest ^{:task 5} n-days-count-disappointing-week-test
   (testing "Count for first three days of disappointing week"
     (is (= 1 (bird-watcher/n-days-count [0, 0, 1, 0, 0, 1, 0] 3)))))
 
-(deftest ^:task5 n-days-count-busy-week-test
+(deftest ^{:task 5} n-days-count-busy-week-test
   (testing "Count for first 6 days of busy week"
     (is (= 48 (bird-watcher/n-days-count [5, 9, 12, 6, 8, 8, 17] 6)))))
 
-(deftest ^:task6 busy-days-disappointing-week-test
+(deftest ^{:task 6} busy-days-disappointing-week-test
   (testing "Busy days for disappointing week"
     (is (= 0 (bird-watcher/busy-days [1 1 1 0 0 0 0])))))
 
-(deftest ^:task6 busy-days-busy-week-test
+(deftest ^{:task 6} busy-days-busy-week-test
   (testing "Busy days for busy week"
     (is (= 5 (bird-watcher/busy-days [4 9 5 7 8 8 2])))))
 
-(deftest ^:task7 odd-week-matching-test
+(deftest ^{:task 7} odd-week-matching-test
   (testing "Odd week for week matching odd pattern"
     (is (= true (bird-watcher/odd-week? [1 0 1 0 1 0 1])))))
 
-(deftest ^:task7 odd-week-not-matching-test
+(deftest ^{:task 7} odd-week-not-matching-test
   (testing "Odd week for week that does not match pattern"
     (is (= false (bird-watcher/odd-week? [2 2 1 0 1 1 1])))))

--- a/exercises/concept/bird-watcher/test/bird_watcher_test.clj
+++ b/exercises/concept/bird-watcher/test/bird_watcher_test.clj
@@ -2,53 +2,53 @@
   (:require [clojure.test :refer [deftest testing is]]
             bird-watcher))
 
-(deftest last-week-test
+(deftest ^:task1 last-week-test
   (is (= [0 2 5 3 7 8 4] bird-watcher/last-week)))
 
-(deftest today-disappointing-week-test
+(deftest ^:task2 today-disappointing-week-test
   (testing "Today's bird count of disappointing week"
     (is (= 0 (bird-watcher/today [0 0 2 0 0 1 0])))))
 
-(deftest today-busy-week-test
+(deftest ^:task2 today-busy-week-test
   (testing "Today's bird count of busy week"
     (is (= 10 (bird-watcher/today [8 8 9 5 4 7 10])))))
 
-(deftest increment-bird-no-visits-test
+(deftest ^:task3 increment-bird-no-visits-test
   (testing "Increment today's count with no previous visits"
     (is (= [6 5 5 11 2 5 1] (bird-watcher/inc-bird [6 5 5 11 2 5 0])))))
 
-(deftest increment-bird-multiple-visits-test
+(deftest ^:task3 increment-bird-multiple-visits-test
   (testing "Increment today's count with multiple previous visits"
     (is (= [5 2 4 2 4 5 8] (bird-watcher/inc-bird [5 2 4 2 4 5 7])))))
 
-(deftest day-without-birds-test
+(deftest ^:task4 day-without-birds-test
   (testing "Has day without birds with day without birds"
     (is (= true (bird-watcher/day-without-birds? [5 5 4 0 7 6 7])))))
 
-(deftest no-day-without-birds-test
+(deftest ^:task4 no-day-without-birds-test
   (testing "Has day without birds with no day without birds"
     (is (= false (bird-watcher/day-without-birds? [5 5 4 1 7 6 7])))))
 
-(deftest n-days-count-disappointing-week-test
+(deftest ^:task5 n-days-count-disappointing-week-test
   (testing "Count for first three days of disappointing week"
     (is (= 1 (bird-watcher/n-days-count [0, 0, 1, 0, 0, 1, 0] 3)))))
 
-(deftest n-days-count-busy-week-test
+(deftest ^:task5 n-days-count-busy-week-test
   (testing "Count for first 6 days of busy week"
     (is (= 48 (bird-watcher/n-days-count [5, 9, 12, 6, 8, 8, 17] 6)))))
 
-(deftest busy-days-disappointing-week-test
+(deftest ^:task6 busy-days-disappointing-week-test
   (testing "Busy days for disappointing week"
     (is (= 0 (bird-watcher/busy-days [1 1 1 0 0 0 0])))))
 
-(deftest busy-days-busy-week-test
+(deftest ^:task6 busy-days-busy-week-test
   (testing "Busy days for busy week"
     (is (= 5 (bird-watcher/busy-days [4 9 5 7 8 8 2])))))
 
-(deftest odd-week-matching-test
+(deftest ^:task7 odd-week-matching-test
   (testing "Odd week for week matching odd pattern"
     (is (= true (bird-watcher/odd-week? [1 0 1 0 1 0 1])))))
 
-(deftest odd-week-not-matching-test
+(deftest ^:task7 odd-week-not-matching-test
   (testing "Odd week for week that does not match pattern"
     (is (= false (bird-watcher/odd-week? [2 2 1 0 1 1 1])))))

--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -1,51 +1,51 @@
 (ns cars-assemble-test
-  (:require [clojure.test :refer [deftest testing is]]
-            cars-assemble))
+  (:require cars-assemble
+            [clojure.test :refer [deftest is testing]]))
 
-(deftest ^:task1 production-rate-speed-0-test
-    (testing "Production rate for speed 0"
-      (is (= 0.0 (cars-assemble/production-rate 0)))))
+(deftest ^{:task 1} production-rate-speed-0-test
+  (testing "Production rate for speed 0"
+    (is (= 0.0 (cars-assemble/production-rate 0)))))
 
-(deftest ^:task1 production-rate-speed-1-test
-    (testing "Production rate for speed 1"
-      (is (= 221.0 (cars-assemble/production-rate 1)))))
+(deftest ^{:task 1} production-rate-speed-1-test
+  (testing "Production rate for speed 1"
+    (is (= 221.0 (cars-assemble/production-rate 1)))))
 
-(deftest ^:task1 production-rate-speed-4-test
-    (testing "Production rate for speed 4"
-      (is (= 884.0 (cars-assemble/production-rate 4)))))
+(deftest ^{:task 1} production-rate-speed-4-test
+  (testing "Production rate for speed 4"
+    (is (= 884.0 (cars-assemble/production-rate 4)))))
 
-(deftest ^:task1 production-rate-speeed-7-test
-    (testing "Production rate for speed 7"
-      (is (= 1392.3 (cars-assemble/production-rate 7)))))
+(deftest ^{:task 1} production-rate-speeed-7-test
+  (testing "Production rate for speed 7"
+    (is (= 1392.3 (cars-assemble/production-rate 7)))))
 
-(deftest ^:task1 production-rate-speed-9-test
-    (testing "Production rate for speed 9"
-      (is (= 1591.2 (cars-assemble/production-rate 9)))))
+(deftest ^{:task 1} production-rate-speed-9-test
+  (testing "Production rate for speed 9"
+    (is (= 1591.2 (cars-assemble/production-rate 9)))))
 
-(deftest ^:task1 production-rate-speed-10-test
-    (testing "Production rate for speed 10"
-      (is (= 1701.7 (cars-assemble/production-rate 10)))))
+(deftest ^{:task 1} production-rate-speed-10-test
+  (testing "Production rate for speed 10"
+    (is (= 1701.7 (cars-assemble/production-rate 10)))))
 
-(deftest ^:task2 working-items-speed-0-test
-    (testing "Working items for speed 0"
-      (is (= 0 (cars-assemble/working-items 0)))))
+(deftest ^{:task 2} working-items-speed-0-test
+  (testing "Working items for speed 0"
+    (is (= 0 (cars-assemble/working-items 0)))))
 
-(deftest ^:task2 working-items-speed-1-test
-    (testing "Working items for speed 1"
-      (is (= 3 (cars-assemble/working-items 1)))))
+(deftest ^{:task 2} working-items-speed-1-test
+  (testing "Working items for speed 1"
+    (is (= 3 (cars-assemble/working-items 1)))))
 
-(deftest ^:task2 working-items-speed-5-test
-    (testing "Working items for speed 5"
-      (is (= 16 (cars-assemble/working-items 5)))))
+(deftest ^{:task 2} working-items-speed-5-test
+  (testing "Working items for speed 5"
+    (is (= 16 (cars-assemble/working-items 5)))))
 
-(deftest ^:task2 working-items-speed-8-test
-    (testing "Working items for speed 8"
-      (is (= 26 (cars-assemble/working-items 8)))))
+(deftest ^{:task 2} working-items-speed-8-test
+  (testing "Working items for speed 8"
+    (is (= 26 (cars-assemble/working-items 8)))))
 
-(deftest ^:task2 working-items-speed-9-test
-    (testing "Working items for speed 9"
-      (is (= 26 (cars-assemble/working-items 9)))))
+(deftest ^{:task 2} working-items-speed-9-test
+  (testing "Working items for speed 9"
+    (is (= 26 (cars-assemble/working-items 9)))))
 
-(deftest ^:task2 working-items-speed-10-test
-    (testing "Working items for speed 10"
-      (is (= 28 (cars-assemble/working-items 10)))))
+(deftest ^{:task 2} working-items-speed-10-test
+  (testing "Working items for speed 10"
+    (is (= 28 (cars-assemble/working-items 10)))))

--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -2,50 +2,50 @@
   (:require [clojure.test :refer [deftest testing is]]
             cars-assemble))
 
-(deftest production-rate-speed-0-test
+(deftest ^:task1 production-rate-speed-0-test
     (testing "Production rate for speed 0"
       (is (= 0.0 (cars-assemble/production-rate 0)))))
 
-(deftest production-rate-speed-1-test
+(deftest ^:task1 production-rate-speed-1-test
     (testing "Production rate for speed 1"
       (is (= 221.0 (cars-assemble/production-rate 1)))))
 
-(deftest production-rate-speed-4-test
+(deftest ^:task1 production-rate-speed-4-test
     (testing "Production rate for speed 4"
       (is (= 884.0 (cars-assemble/production-rate 4)))))
 
-(deftest production-rate-speeed-7-test
+(deftest ^:task1 production-rate-speeed-7-test
     (testing "Production rate for speed 7"
       (is (= 1392.3 (cars-assemble/production-rate 7)))))
 
-(deftest production-rate-speed-9-test
+(deftest ^:task1 production-rate-speed-9-test
     (testing "Production rate for speed 9"
       (is (= 1591.2 (cars-assemble/production-rate 9)))))
 
-(deftest production-rate-speed-10-test
+(deftest ^:task1 production-rate-speed-10-test
     (testing "Production rate for speed 10"
       (is (= 1701.7 (cars-assemble/production-rate 10)))))
 
-(deftest working-items-speed-0-test
+(deftest ^:task2 working-items-speed-0-test
     (testing "Working items for speed 0"
       (is (= 0 (cars-assemble/working-items 0)))))
 
-(deftest working-items-speed-1-test
+(deftest ^:task2 working-items-speed-1-test
     (testing "Working items for speed 1"
       (is (= 3 (cars-assemble/working-items 1)))))
 
-(deftest working-items-speed-5-test
+(deftest ^:task2 working-items-speed-5-test
     (testing "Working items for speed 5"
       (is (= 16 (cars-assemble/working-items 5)))))
 
-(deftest working-items-speed-8-test
+(deftest ^:task2 working-items-speed-8-test
     (testing "Working items for speed 8"
       (is (= 26 (cars-assemble/working-items 8)))))
 
-(deftest working-items-speed-9-test
+(deftest ^:task2 working-items-speed-9-test
     (testing "Working items for speed 9"
       (is (= 26 (cars-assemble/working-items 9)))))
 
-(deftest working-items-speed-10-test
+(deftest ^:task2 working-items-speed-10-test
     (testing "Working items for speed 10"
       (is (= 28 (cars-assemble/working-items 10)))))

--- a/exercises/concept/date-parser/test/date_parser_test.clj
+++ b/exercises/concept/date-parser/test/date_parser_test.clj
@@ -1,8 +1,8 @@
 (ns date-parser-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest is testing]]
             exercism.date-parser))
 
-(deftest day-test
+(deftest ^{:task 1} day-test
   (testing "numeric pattern for day matches"
     (testing "un-padded 1"
       (is (= "1" (re-matches (re-pattern exercism.date-parser/day) "1"))))
@@ -94,7 +94,7 @@
     (testing "two letters"
       (is (nil? (re-matches (re-pattern exercism.date-parser/day) "bb"))))))
 
-(deftest month-test
+(deftest ^{:task 1} month-test
   (testing "numeric pattern for month matches"
     (testing "un-padded 1"
       (is (= "1" (re-matches (re-pattern exercism.date-parser/month) "1"))))
@@ -152,7 +152,7 @@
     (testing "long month name"
       (is (nil? (re-matches (re-pattern exercism.date-parser/month) "January"))))))
 
-(deftest year-test
+(deftest ^{:task 1} year-test
   (testing "numeric pattern for year"
     (testing "matches 4 digits"
       (is (= "1970" (re-matches (re-pattern exercism.date-parser/year) "1970"))))
@@ -165,7 +165,7 @@
     (testing "doesn't match too many"
       (is (nil? (re-matches (re-pattern exercism.date-parser/year) "19701"))))))
 
-(deftest day-names-test
+(deftest ^{:task 2} day-names-test
   (testing "day names match"
     (is (= "Sunday" (exercism.date-parser/day-names "Sunday")))
     (is (= "Monday" (exercism.date-parser/day-names "Monday")))
@@ -184,7 +184,7 @@
     (testing "numeric day of the week (1-indexed)"
       (is (nil? (exercism.date-parser/day-names "1"))))))
 
-(deftest month-names-test
+(deftest ^{:task 2} month-names-test
   (testing "month names match"
     (is (= "January" (exercism.date-parser/month-names "January")))
     (is (= "February" (exercism.date-parser/month-names "February")))
@@ -208,7 +208,7 @@
     (testing "numeric month of the year (1-indexed)"
       (is (nil? (exercism.date-parser/month-names "1"))))))
 
-(deftest capture-test
+(deftest ^{:task 3} capture-test
   (testing "capture numeric month"
     (is (= {:month "01"} (exercism.date-parser/capture-month "01"))))
   (testing "capture numeric day"
@@ -218,7 +218,9 @@
   (testing "capture day name"
     (is (= {:day-name "Monday"} (exercism.date-parser/capture-day-name "Monday"))))
   (testing "capture month name"
-    (is (= {:month-name "February"} (exercism.date-parser/capture-month-name "February"))))
+    (is (= {:month-name "February"} (exercism.date-parser/capture-month-name "February")))))
+
+(deftest ^{:task 4} combined-capture-test
   (testing "numeric date"
     (is (= {:year "1970", :month "02", :day "01"} (exercism.date-parser/capture-numeric-date "01/02/1970"))))
   (testing "month named date"

--- a/exercises/concept/elyses-destructured-enchantments/test/elyses_destructured_enchantments_test.clj
+++ b/exercises/concept/elyses-destructured-enchantments/test/elyses_destructured_enchantments_test.clj
@@ -2,41 +2,41 @@
   (:require [clojure.test :refer :all]
             [elyses-destructured-enchantments :refer :all]))
 
-(deftest first-card-single-test
+(deftest ^:task1 first-card-single-test
   (is (= (first-card [3]) 3)))
 
-(deftest first-card-multiple-test
+(deftest ^:task1 first-card-multiple-test
   (is (= (first-card [8 3 9 5]) 8)))
 
-(deftest second-card-2-test
+(deftest ^:task2 second-card-2-test
   (is (= (second-card [10 4]) 4)))
 
-(deftest second-card-4-test
+(deftest ^:task2 second-card-4-test
   (is (= (second-card [2 5 1 6]) 5)))
 
-(deftest second-card-empty-test
+(deftest ^:task2 second-card-empty-test
   (is (nil? (second-card []))))
 
-(deftest second-card-single-test
+(deftest ^:task2 second-card-single-test
   (is (nil? (second-card [8]))))
 
-(deftest swap-top-two-cards-2-test
+(deftest ^:task3 swap-top-two-cards-2-test
   (is (= (swap-top-two-cards [3 6]) [6 3])))
 
-(deftest swap-top-two-cards-5-test
+(deftest ^:task3 swap-top-two-cards-5-test
   (is (= (swap-top-two-cards [10 4 3 7 8]) [4 10 3 7 8])))
 
-(deftest discard-top-card-single-test
+(deftest ^:task4 discard-top-card-single-test
   (is (= (discard-top-card [7]) [7 nil])))
 
-(deftest discard-top-card-4-test
+(deftest ^:task4 discard-top-card-4-test
   (is (= (discard-top-card [9 2 10 4]) [9 [2 10 4]])))
 
-(deftest insert-face-cards-3-test
+(deftest ^:task5 insert-face-cards-3-test
   (is (= (insert-face-cards [3 10 7]) [3 "jack" "queen" "king" 10 7])))
 
-(deftest insert-face-cards-1-test
+(deftest ^:task5 insert-face-cards-1-test
   (is (= (insert-face-cards [9]) [9 "jack" "queen" "king"])))
 
-(deftest insert-face-cards-empty-test
+(deftest ^:task5 insert-face-cards-empty-test
   (is (= (insert-face-cards []) ["jack" "queen" "king"])))

--- a/exercises/concept/elyses-destructured-enchantments/test/elyses_destructured_enchantments_test.clj
+++ b/exercises/concept/elyses-destructured-enchantments/test/elyses_destructured_enchantments_test.clj
@@ -2,41 +2,41 @@
   (:require [clojure.test :refer :all]
             [elyses-destructured-enchantments :refer :all]))
 
-(deftest ^:task1 first-card-single-test
+(deftest ^{:task 1} first-card-single-test
   (is (= (first-card [3]) 3)))
 
-(deftest ^:task1 first-card-multiple-test
+(deftest ^{:task 1} first-card-multiple-test
   (is (= (first-card [8 3 9 5]) 8)))
 
-(deftest ^:task2 second-card-2-test
+(deftest ^{:task 2} second-card-2-test
   (is (= (second-card [10 4]) 4)))
 
-(deftest ^:task2 second-card-4-test
+(deftest ^{:task 2} second-card-4-test
   (is (= (second-card [2 5 1 6]) 5)))
 
-(deftest ^:task2 second-card-empty-test
+(deftest ^{:task 2} second-card-empty-test
   (is (nil? (second-card []))))
 
-(deftest ^:task2 second-card-single-test
+(deftest ^{:task 2} second-card-single-test
   (is (nil? (second-card [8]))))
 
-(deftest ^:task3 swap-top-two-cards-2-test
+(deftest ^{:task 3} swap-top-two-cards-2-test
   (is (= (swap-top-two-cards [3 6]) [6 3])))
 
-(deftest ^:task3 swap-top-two-cards-5-test
+(deftest ^{:task 3} swap-top-two-cards-5-test
   (is (= (swap-top-two-cards [10 4 3 7 8]) [4 10 3 7 8])))
 
-(deftest ^:task4 discard-top-card-single-test
+(deftest ^{:task 4} discard-top-card-single-test
   (is (= (discard-top-card [7]) [7 nil])))
 
-(deftest ^:task4 discard-top-card-4-test
+(deftest ^{:task 4} discard-top-card-4-test
   (is (= (discard-top-card [9 2 10 4]) [9 [2 10 4]])))
 
-(deftest ^:task5 insert-face-cards-3-test
+(deftest ^{:task 5} insert-face-cards-3-test
   (is (= (insert-face-cards [3 10 7]) [3 "jack" "queen" "king" 10 7])))
 
-(deftest ^:task5 insert-face-cards-1-test
+(deftest ^{:task 5} insert-face-cards-1-test
   (is (= (insert-face-cards [9]) [9 "jack" "queen" "king"])))
 
-(deftest ^:task5 insert-face-cards-empty-test
+(deftest ^{:task 5} insert-face-cards-empty-test
   (is (= (insert-face-cards []) ["jack" "queen" "king"])))

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -1,84 +1,84 @@
 (ns interest-is-interesting-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest is]]
             interest-is-interesting))
 
-(deftest ^:task1 minimal-first-interest-rate-test
+(deftest ^{:task 1} minimal-first-interest-rate-test
   (is (= 0.5 (interest-is-interesting/interest-rate 0M))))
 
-(deftest ^:task1 tiny-first-interest-rate-test
+(deftest ^{:task 1} tiny-first-interest-rate-test
   (is (= 0.5 (interest-is-interesting/interest-rate 0.000001M))))
 
-(deftest ^:task1 maximum-first-interest-rate-test
+(deftest ^{:task 1} maximum-first-interest-rate-test
   (is (= 0.5 (interest-is-interesting/interest-rate 999.9999M))))
 
-(deftest ^:task1 minimal-second-interest-rate-test
+(deftest ^{:task 1} minimal-second-interest-rate-test
   (is (= 1.621 (interest-is-interesting/interest-rate 1000.0M))))
 
-(deftest ^:task1 tiny-second-interest-rate-test
+(deftest ^{:task 1} tiny-second-interest-rate-test
   (is (= 1.621 (interest-is-interesting/interest-rate 1000.0001M))))
 
-(deftest ^:task1 maximum-second-interest-rate-test
+(deftest ^{:task 1} maximum-second-interest-rate-test
   (is (= 1.621 (interest-is-interesting/interest-rate 4999.9990M))))
 
-(deftest ^:task1 minimal-third-interest-rate-test
+(deftest ^{:task 1} minimal-third-interest-rate-test
   (is (= 2.475 (interest-is-interesting/interest-rate 5000.0000M))))
 
-(deftest ^:task1 tiny-third-interest-rate-test
+(deftest ^{:task 1} tiny-third-interest-rate-test
   (is (= 2.475 (interest-is-interesting/interest-rate 5000.0001M))))
 
-(deftest ^:task1 large-third-interest-rate-test
+(deftest ^{:task 1} large-third-interest-rate-test
   (is (= 2.475 (interest-is-interesting/interest-rate 5639998.742909M))))
 
-(deftest ^:task1 minimal-negative-interest-rate-test
+(deftest ^{:task 1} minimal-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -0.000001M))))
 
-(deftest ^:task1 small-negative-interest-rate-test
+(deftest ^{:task 1} small-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -0.123M))))
 
-(deftest ^:task1 regular-negative-interest-rate-test
+(deftest ^{:task 1} regular-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -300.0M))))
 
-(deftest ^:task1 large-negative-interest-rate-test
+(deftest ^{:task 1} large-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -152964.231M))))
 
-(deftest ^:task2 annual-balance-update-empty-balance-test
+(deftest ^{:task 2} annual-balance-update-empty-balance-test
   (is (= 0.0000M (interest-is-interesting/annual-balance-update 0.0M))))
 
-(deftest ^:task2 annual-balance-update-small-positive-balance-test
+(deftest ^{:task 2} annual-balance-update-small-positive-balance-test
   (is (= 0.000001005M (interest-is-interesting/annual-balance-update 0.000001M))))
 
-(deftest ^:task2 annual-balance-update-average-positive-balance-test
+(deftest ^{:task 2} annual-balance-update-average-positive-balance-test
   (is (= 1016.210000M (interest-is-interesting/annual-balance-update 1000.0M))))
 
-(deftest ^:task2 annual-balance-update-large-positive-balance-test
+(deftest ^{:task 2} annual-balance-update-large-positive-balance-test
   (is (= 1016.210101621M (interest-is-interesting/annual-balance-update 1000.0001M))))
 
-(deftest ^:task2 annual-balance-update-huge-positive-balance-test
+(deftest ^{:task 2} annual-balance-update-huge-positive-balance-test
   (is (= 920352587.26744292868451875M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))
 
-(deftest ^:task2 annual-balance-update-small-negative-balance-test
+(deftest ^{:task 2} annual-balance-update-small-negative-balance-test
   (is (= -0.12695199M (interest-is-interesting/annual-balance-update -0.123M))))
 
-(deftest ^:task2 annual-balance-update-large-negative-balance-test
+(deftest ^{:task 2} annual-balance-update-large-negative-balance-test
   (is (= -157878.97174203M (interest-is-interesting/annual-balance-update -152964.231M))))
 
-(deftest ^:task3 amount-to-donate-empty-balance-test
+(deftest ^{:task 3} amount-to-donate-empty-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate 0.0M 2.0))))
 
-(deftest ^:task3 amount-to-donate-small-positive-balance-test
+(deftest ^{:task 3} amount-to-donate-small-positive-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate 0.000001M 2.1))))
 
-(deftest ^:task3 amount-to-donate-average-positive-balance-test
+(deftest ^{:task 3} amount-to-donate-average-positive-balance-test
   (is (= 40 (interest-is-interesting/amount-to-donate 1000.0M 2.0))))
 
-(deftest ^:task3 amount-to-donate-large-positive-balance-test
+(deftest ^{:task 3} amount-to-donate-large-positive-balance-test
   (is (= 19 (interest-is-interesting/amount-to-donate 1000.0001M 0.99))))
 
-(deftest ^:task3 amount-to-donate-huge-positive-balance-test
+(deftest ^{:task 3} amount-to-donate-huge-positive-balance-test
   (is (= 47600572 (interest-is-interesting/amount-to-donate 898124017.826243404425M 2.65))))
 
-(deftest ^:task3 amount-to-donate-small-negative-balance-test
+(deftest ^{:task 3} amount-to-donate-small-negative-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate -0.123M 3.33))))
 
-(deftest ^:task3 amount-to-donate-large-negative-balance-test
+(deftest ^{:task 3} amount-to-donate-large-negative-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate -152964.231M 5.4))))

--- a/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
+++ b/exercises/concept/interest-is-interesting/test/interest_is_interesting_test.clj
@@ -2,83 +2,83 @@
   (:require [clojure.test :refer [deftest testing is]]
             interest-is-interesting))
 
-(deftest minimal-first-interest-rate-test
+(deftest ^:task1 minimal-first-interest-rate-test
   (is (= 0.5 (interest-is-interesting/interest-rate 0M))))
 
-(deftest tiny-first-interest-rate-test
+(deftest ^:task1 tiny-first-interest-rate-test
   (is (= 0.5 (interest-is-interesting/interest-rate 0.000001M))))
 
-(deftest maximum-first-interest-rate-test
+(deftest ^:task1 maximum-first-interest-rate-test
   (is (= 0.5 (interest-is-interesting/interest-rate 999.9999M))))
 
-(deftest minimal-second-interest-rate-test
+(deftest ^:task1 minimal-second-interest-rate-test
   (is (= 1.621 (interest-is-interesting/interest-rate 1000.0M))))
 
-(deftest tiny-second-interest-rate-test
+(deftest ^:task1 tiny-second-interest-rate-test
   (is (= 1.621 (interest-is-interesting/interest-rate 1000.0001M))))
 
-(deftest maximum-second-interest-rate-test
+(deftest ^:task1 maximum-second-interest-rate-test
   (is (= 1.621 (interest-is-interesting/interest-rate 4999.9990M))))
 
-(deftest minimal-third-interest-rate-test
+(deftest ^:task1 minimal-third-interest-rate-test
   (is (= 2.475 (interest-is-interesting/interest-rate 5000.0000M))))
 
-(deftest tiny-third-interest-rate-test
+(deftest ^:task1 tiny-third-interest-rate-test
   (is (= 2.475 (interest-is-interesting/interest-rate 5000.0001M))))
 
-(deftest large-third-interest-rate-test
+(deftest ^:task1 large-third-interest-rate-test
   (is (= 2.475 (interest-is-interesting/interest-rate 5639998.742909M))))
 
-(deftest minimal-negative-interest-rate-test
+(deftest ^:task1 minimal-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -0.000001M))))
 
-(deftest small-negative-interest-rate-test
+(deftest ^:task1 small-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -0.123M))))
 
-(deftest regular-negative-interest-rate-test
+(deftest ^:task1 regular-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -300.0M))))
 
-(deftest large-negative-interest-rate-test
+(deftest ^:task1 large-negative-interest-rate-test
   (is (= -3.213 (interest-is-interesting/interest-rate -152964.231M))))
 
-(deftest annual-balance-update-empty-balance-test
+(deftest ^:task2 annual-balance-update-empty-balance-test
   (is (= 0.0000M (interest-is-interesting/annual-balance-update 0.0M))))
 
-(deftest annual-balance-update-small-positive-balance-test
+(deftest ^:task2 annual-balance-update-small-positive-balance-test
   (is (= 0.000001005M (interest-is-interesting/annual-balance-update 0.000001M))))
 
-(deftest annual-balance-update-average-positive-balance-test
+(deftest ^:task2 annual-balance-update-average-positive-balance-test
   (is (= 1016.210000M (interest-is-interesting/annual-balance-update 1000.0M))))
 
-(deftest annual-balance-update-large-positive-balance-test
+(deftest ^:task2 annual-balance-update-large-positive-balance-test
   (is (= 1016.210101621M (interest-is-interesting/annual-balance-update 1000.0001M))))
 
-(deftest annual-balance-update-huge-positive-balance-test
+(deftest ^:task2 annual-balance-update-huge-positive-balance-test
   (is (= 920352587.26744292868451875M (interest-is-interesting/annual-balance-update 898124017.826243404425M))))
 
-(deftest annual-balance-update-small-negative-balance-test
+(deftest ^:task2 annual-balance-update-small-negative-balance-test
   (is (= -0.12695199M (interest-is-interesting/annual-balance-update -0.123M))))
 
-(deftest annual-balance-update-large-negative-balance-test
+(deftest ^:task2 annual-balance-update-large-negative-balance-test
   (is (= -157878.97174203M (interest-is-interesting/annual-balance-update -152964.231M))))
 
-(deftest amount-to-donate-empty-balance-test
+(deftest ^:task3 amount-to-donate-empty-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate 0.0M 2.0))))
 
-(deftest amount-to-donate-small-positive-balance-test
+(deftest ^:task3 amount-to-donate-small-positive-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate 0.000001M 2.1))))
 
-(deftest amount-to-donate-average-positive-balance-test
+(deftest ^:task3 amount-to-donate-average-positive-balance-test
   (is (= 40 (interest-is-interesting/amount-to-donate 1000.0M 2.0))))
 
-(deftest amount-to-donate-large-positive-balance-test
+(deftest ^:task3 amount-to-donate-large-positive-balance-test
   (is (= 19 (interest-is-interesting/amount-to-donate 1000.0001M 0.99))))
 
-(deftest amount-to-donate-huge-positive-balance-test
+(deftest ^:task3 amount-to-donate-huge-positive-balance-test
   (is (= 47600572 (interest-is-interesting/amount-to-donate 898124017.826243404425M 2.65))))
 
-(deftest amount-to-donate-small-negative-balance-test
+(deftest ^:task3 amount-to-donate-small-negative-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate -0.123M 3.33))))
 
-(deftest amount-to-donate-large-negative-balance-test
+(deftest ^:task3 amount-to-donate-large-negative-balance-test
   (is (= 0 (interest-is-interesting/amount-to-donate -152964.231M 5.4))))

--- a/exercises/concept/international-calling-connoisseur/test/international_calling_connoisseur_test.clj
+++ b/exercises/concept/international-calling-connoisseur/test/international_calling_connoisseur_test.clj
@@ -2,98 +2,98 @@
   (:require [clojure.test :refer [deftest testing is]]
             international-calling-connoisseur))
 
-(deftest map-count-is-3
+(deftest ^{:task 1} map-count-is-3
   (is (= 3 (count international-calling-connoisseur/countries))))
 
-(deftest United-States-of-America-is-1
+(deftest ^{:task 1} United-States-of-America-is-1
   (is (= "United States of America" (get international-calling-connoisseur/countries 1))))
 
-(deftest Brazil-is-55
+(deftest ^{:task 1} Brazil-is-55
   (is (= "Brazil" (get international-calling-connoisseur/countries 55))))
 
-(deftest India-is-55
+(deftest ^{:task 1} India-is-55
   (is (= "India" (get international-calling-connoisseur/countries 91))))
 
-(deftest add-country-to-empty-map-single
+(deftest ^{:task 2} add-country-to-empty-map-single
   (is (= 1 (count (international-calling-connoisseur/add-country {} 44 "United Kingdom")))))
 
-(deftest add-country-to-empty-map-44-is-United-Kingdom
+(deftest ^{:task 2} add-country-to-empty-map-44-is-United-Kingdom
   (is (= "United Kingdom" (get (international-calling-connoisseur/add-country {} 44 "United Kingdom") 44))))
 
-(deftest add-country-to-country-map-count-is-4
+(deftest ^{:task 2} add-country-to-country-map-count-is-4
   (is (= 4 (count (international-calling-connoisseur/add-country international-calling-connoisseur/countries 44 "United Kingdom")))))
 
-(deftest add-country-to-country-map-1-is-United-States-of-America
+(deftest ^{:task 2} add-country-to-country-map-1-is-United-States-of-America
   (is (= "United States of America" (get (international-calling-connoisseur/add-country international-calling-connoisseur/countries 44 "United Kingdom") 1))))
 
-(deftest add-country-to-country-map-44-is-United-Kingdom
+(deftest ^{:task 2} add-country-to-country-map-44-is-United-Kingdom
   (is (= "United Kingdom" (get (international-calling-connoisseur/add-country international-calling-connoisseur/countries 44 "United Kingdom") 44))))
 
-(deftest add-country-to-country-map-55-is-Brazil
+(deftest ^{:task 2} add-country-to-country-map-55-is-Brazil
   (is (= "Brazil" (get (international-calling-connoisseur/add-country international-calling-connoisseur/countries 44 "United Kingdom") 55))))
 
-(deftest add-country-to-country-map-91-is-India
+(deftest ^{:task 2} add-country-to-country-map-91-is-India
   (is (= "India" (get (international-calling-connoisseur/add-country international-calling-connoisseur/countries 44 "United Kingdom") 91))))
 
-(deftest get-country-name-from-map
+(deftest ^{:task 3} get-country-name-from-map
   (is (= "Brazil" (international-calling-connoisseur/country-name international-calling-connoisseur/countries 55))))
 
-(deftest get-country-name-for-non-existent-country
+(deftest ^{:task 3} get-country-name-for-non-existent-country
   (is (nil? (international-calling-connoisseur/country-name international-calling-connoisseur/countries 999))))
 
-(deftest check-country-exists
+(deftest ^{:task 5} check-country-exists
   (is (true? (international-calling-connoisseur/code-exists? international-calling-connoisseur/countries 55))))
 
-(deftest check-non-existent-country-exists
+(deftest ^{:task 5} check-non-existent-country-exists
   (is (false? (international-calling-connoisseur/code-exists? international-calling-connoisseur/countries 999))))
 
-(deftest update-name-in-map-count-is-3
+(deftest ^{:task 4} update-name-in-map-count-is-3
   (is (= 3 (count (international-calling-connoisseur/update-country international-calling-connoisseur/countries 1 "les États-Unis")))))
 
-(deftest update-name-in-map-1-is-les-Etats-Unis
+(deftest ^{:task 4} update-name-in-map-1-is-les-Etats-Unis
   (is (= "les États-Unis" (get (international-calling-connoisseur/update-country international-calling-connoisseur/countries 1 "les États-Unis") 1))))
 
-(deftest update-name-in-map-55-is-Brazil
+(deftest ^{:task 4} update-name-in-map-55-is-Brazil
   (is (= "Brazil" (get (international-calling-connoisseur/update-country international-calling-connoisseur/countries 1 "les États-Unis") 55))))
 
-(deftest update-name-in-map-91-is-India
+(deftest ^{:task 4} update-name-in-map-91-is-India
   (is (= "India" (get (international-calling-connoisseur/update-country international-calling-connoisseur/countries 1 "les États-Unis") 91))))
 
-(deftest update-non-existent-name-in-map-count-is-3
+(deftest ^{:task 6} update-non-existent-name-in-map-count-is-3
   (is (= 3 (count (international-calling-connoisseur/update-country international-calling-connoisseur/countries 999 "Newlands")))))
 
-(deftest update-non-existent-name-in-map-1-is-United-States-of-America
+(deftest ^{:task 6} update-non-existent-name-in-map-1-is-United-States-of-America
   (is (= "United States of America" (get (international-calling-connoisseur/update-country international-calling-connoisseur/countries 999 "Newlands") 1))))
 
-(deftest update-non-existent-name-in-map-55-is-Brazil
+(deftest ^{:task 6} update-non-existent-name-in-map-55-is-Brazil
   (is (= "Brazil" (get (international-calling-connoisseur/update-country international-calling-connoisseur/countries 999 "Newlands") 55))))
 
-(deftest update-non-existent-name-in-map-91-is-India
+(deftest ^{:task 6} update-non-existent-name-in-map-91-is-India
   (is (= "India" (get (international-calling-connoisseur/update-country international-calling-connoisseur/countries 999 "Newlands") 91))))
 
-(deftest remove-country-from-map-count-is-2
+(deftest ^{:task 7} remove-country-from-map-count-is-2
   (is (= 2 (count (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 91)))))
 
-(deftest remove-country-from-map-1-is-United-States-of-America
+(deftest ^{:task 7} remove-country-from-map-1-is-United-States-of-America
   (is (= "United States of America" (get (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 44) 1))))
 
-(deftest remove-country-from-map-55-is-Brazil
+(deftest ^{:task 7} remove-country-from-map-55-is-Brazil
   (is (= "Brazil" (get (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 44) 55))))
 
-(deftest remove-non-existent-country-from-map-count-is-3
+(deftest ^{:task 7} remove-non-existent-country-from-map-count-is-3
   (is (= 3 (count (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 999)))))
 
-(deftest remove-non-existent-country-from-map-1-is-United-States-of-America
+(deftest ^{:task 7} remove-non-existent-country-from-map-1-is-United-States-of-America
   (is (= "United States of America" (get (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 999) 1))))
 
-(deftest remove-non-existent-country-from-map-55-is-Brazil
+(deftest ^{:task 7} remove-non-existent-country-from-map-55-is-Brazil
   (is (= "Brazil" (get (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 999) 55))))
 
-(deftest remove-non-existent-country-from-map-91-is-India
+(deftest ^{:task 7} remove-non-existent-country-from-map-91-is-India
   (is (= "India" (get (international-calling-connoisseur/remove-country international-calling-connoisseur/countries 999) 91))))
 
-(deftest longest-name
+(deftest ^{:task 8} longest-name
   (is (= "United States of America" (international-calling-connoisseur/longest-name international-calling-connoisseur/countries))))
 
-(deftest longest-name-empty-map
+(deftest ^{:task 8} longest-name-empty-map
   (is (nil? (international-calling-connoisseur/longest-name {}))))

--- a/exercises/concept/log-levels/test/log_levels_test.clj
+++ b/exercises/concept/log-levels/test/log_levels_test.clj
@@ -2,35 +2,35 @@
   (:require [clojure.test :refer [deftest testing is]]
             log-levels))
 
-(deftest message-error-test
+(deftest ^:task1 message-error-test
   (is (= "Stack overflow" (log-levels/message "[ERROR]: Stack overflow"))))
 
-(deftest message-warning-test
+(deftest ^:task1 message-warning-test
   (is (= (log-levels/message "[WARNING]: Disk almost full") "Disk almost full")))
 
-(deftest message-info-test
+(deftest ^:task1 message-info-test
   (is (= (log-levels/message "[INFO]: File moved") "File moved")))
 
-(deftest message-trim-whitespace-test
+(deftest ^:task1 message-trim-whitespace-test
   (is (= "Timezone not set" (log-levels/message "[WARNING]:   \tTimezone not set  \r\n"))))
 
-(deftest log-level-error-test
+(deftest ^:task2 log-level-error-test
   (is (= "error" (log-levels/log-level "[ERROR]: Disk full"))))
 
-(deftest log-level-warning-test
+(deftest ^:task2 log-level-warning-test
   (is (= "warning" (log-levels/log-level "[WARNING]: Unsafe password"))))
 
-(deftest log-level-info-test
+(deftest ^:task2 log-level-info-test
   (is (= "info" (log-levels/log-level "[INFO]: Timezone changed"))))
 
-(deftest reformat-error-test
+(deftest ^:task3 reformat-error-test
   (is (= "Segmentation fault (error)" (log-levels/reformat "[ERROR]: Segmentation fault"))))
 
-(deftest reformat-warning-test
+(deftest ^:task3 reformat-warning-test
   (is (= "Decreased performance (warning)" (log-levels/reformat "[WARNING]: Decreased performance"))))
 
-(deftest reformat-info-test
+(deftest ^:task3 reformat-info-test
   (is (= "Disk defragmented (info)" (log-levels/reformat "[INFO]: Disk defragmented"))))
 
-(deftest reformat-trim-whitespace-test
+(deftest ^:task3 reformat-trim-whitespace-test
   (is (= "Corrupt disk (error)" (log-levels/reformat "[ERROR]: \t Corrupt disk\t \t \r\n"))))

--- a/exercises/concept/log-levels/test/log_levels_test.clj
+++ b/exercises/concept/log-levels/test/log_levels_test.clj
@@ -1,36 +1,36 @@
 (ns log-levels-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest is]]
             log-levels))
 
-(deftest ^:task1 message-error-test
+(deftest ^{:task 1} message-error-test
   (is (= "Stack overflow" (log-levels/message "[ERROR]: Stack overflow"))))
 
-(deftest ^:task1 message-warning-test
+(deftest ^{:task 1} message-warning-test
   (is (= (log-levels/message "[WARNING]: Disk almost full") "Disk almost full")))
 
-(deftest ^:task1 message-info-test
+(deftest ^{:task 1} message-info-test
   (is (= (log-levels/message "[INFO]: File moved") "File moved")))
 
-(deftest ^:task1 message-trim-whitespace-test
+(deftest ^{:task 1} message-trim-whitespace-test
   (is (= "Timezone not set" (log-levels/message "[WARNING]:   \tTimezone not set  \r\n"))))
 
-(deftest ^:task2 log-level-error-test
+(deftest ^{:task 2} log-level-error-test
   (is (= "error" (log-levels/log-level "[ERROR]: Disk full"))))
 
-(deftest ^:task2 log-level-warning-test
+(deftest ^{:task 2} log-level-warning-test
   (is (= "warning" (log-levels/log-level "[WARNING]: Unsafe password"))))
 
-(deftest ^:task2 log-level-info-test
+(deftest ^{:task 2} log-level-info-test
   (is (= "info" (log-levels/log-level "[INFO]: Timezone changed"))))
 
-(deftest ^:task3 reformat-error-test
+(deftest ^{:task 3} reformat-error-test
   (is (= "Segmentation fault (error)" (log-levels/reformat "[ERROR]: Segmentation fault"))))
 
-(deftest ^:task3 reformat-warning-test
+(deftest ^{:task 3} reformat-warning-test
   (is (= "Decreased performance (warning)" (log-levels/reformat "[WARNING]: Decreased performance"))))
 
-(deftest ^:task3 reformat-info-test
+(deftest ^{:task 3} reformat-info-test
   (is (= "Disk defragmented (info)" (log-levels/reformat "[INFO]: Disk defragmented"))))
 
-(deftest ^:task3 reformat-trim-whitespace-test
+(deftest ^{:task 3} reformat-trim-whitespace-test
   (is (= "Corrupt disk (error)" (log-levels/reformat "[ERROR]: \t Corrupt disk\t \t \r\n"))))

--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -1,21 +1,21 @@
 (ns lucians-luscious-lasagna-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest is]]
             lucians-luscious-lasagna))
 
-(deftest ^:task1 expected-time-test
+(deftest ^{:task 1} expected-time-test
   (is (= 40 lucians-luscious-lasagna/expected-time)))
 
-(deftest ^:task2 remaining-time-test
+(deftest ^{:task 2} remaining-time-test
   (is (= 15 (lucians-luscious-lasagna/remaining-time 25))))
 
-(deftest ^:task3 prep-time-one-layer-test
+(deftest ^{:task 3} prep-time-one-layer-test
   (is (= 2 (lucians-luscious-lasagna/prep-time 1))))
 
-(deftest ^:task3 prep-time-multiple-layers-test
+(deftest ^{:task 3} prep-time-multiple-layers-test
   (is (= 8 (lucians-luscious-lasagna/prep-time 4))))
 
-(deftest ^:task4 total-time-one-layer-test
+(deftest ^{:task 4} total-time-one-layer-test
   (is (= 32 (lucians-luscious-lasagna/total-time 1 30))))
 
-(deftest ^:task4 total-time-multiple-layers-test
+(deftest ^{:task 4} total-time-multiple-layers-test
   (is (= 16 (lucians-luscious-lasagna/total-time 4 8))))

--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -2,20 +2,20 @@
   (:require [clojure.test :refer [deftest testing is]]
             lucians-luscious-lasagna))
 
-(deftest expected-time-test
+(deftest ^:task1 expected-time-test
   (is (= 40 lucians-luscious-lasagna/expected-time)))
 
-(deftest remaining-time-test
+(deftest ^:task2 remaining-time-test
   (is (= 15 (lucians-luscious-lasagna/remaining-time 25))))
 
-(deftest prep-time-one-layer-test
+(deftest ^:task3 prep-time-one-layer-test
   (is (= 2 (lucians-luscious-lasagna/prep-time 1))))
 
-(deftest prep-time-multiple-layers-test
+(deftest ^:task3 prep-time-multiple-layers-test
   (is (= 8 (lucians-luscious-lasagna/prep-time 4))))
 
-(deftest total-time-one-layer-test
+(deftest ^:task4 total-time-one-layer-test
   (is (= 32 (lucians-luscious-lasagna/total-time 1 30))))
 
-(deftest total-time-multiple-layers-test
+(deftest ^:task4 total-time-multiple-layers-test
   (is (= 16 (lucians-luscious-lasagna/total-time 4 8))))

--- a/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
+++ b/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
@@ -2,29 +2,29 @@
   (:require [clojure.test :refer [deftest testing is]]
             squeaky-clean))
 
-(deftest clean-single-letter
+(deftest ^:task1 clean-single-letter
   (is (= "A" (squeaky-clean/clean "A"))))
 
-(deftest clean-clean-string
+(deftest ^:task1 clean-clean-string
   (is (= "àḃç" (squeaky-clean/clean "àḃç"))))
 
-(deftest clean-string-with-spaces
+(deftest ^:task1 clean-string-with-spaces
   (is (= "my___Id" (squeaky-clean/clean "my   Id"))))
 
-(deftest clean-string-with-control-char
-  (is (= "myCTRLId" (squeaky-clean/clean "my\u0000Id"))))
-
-(deftest clean-string-with-no-letters
+(deftest ^:task1 clean-string-with-no-letters
   (is (= "" (squeaky-clean/clean "😀😀😀"))))
 
-(deftest clean-empty-string
+(deftest ^:task1 clean-empty-string
   (is (= "" (squeaky-clean/clean ""))))
 
-(deftest convert-kebab-to-camel-case
+(deftest ^:task2 clean-string-with-control-char
+  (is (= "myCTRLId" (squeaky-clean/clean "my\u0000Id"))))
+
+(deftest ^:task3 convert-kebab-to-camel-case
   (is (= "àḂç" (squeaky-clean/clean "à-ḃç"))))
 
-(deftest omit-lower-case-greek-letters
+(deftest ^:task4 omit-lower-case-greek-letters
   (is (= "MyΟFinder" (squeaky-clean/clean "MyΟβιεγτFinder"))))
 
-(deftest combine-conversions
+(deftest ^:task3 combine-conversions
   (is (= "_AbcĐCTRL" (squeaky-clean/clean "9 -abcĐ😀ω\0"))))

--- a/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
+++ b/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
@@ -1,30 +1,30 @@
 (ns squeaky-clean-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest is]]
             squeaky-clean))
 
-(deftest ^:task1 clean-single-letter
+(deftest ^{:task 1} clean-single-letter
   (is (= "A" (squeaky-clean/clean "A"))))
 
-(deftest ^:task1 clean-clean-string
+(deftest ^{:task 1} clean-clean-string
   (is (= "àḃç" (squeaky-clean/clean "àḃç"))))
 
-(deftest ^:task1 clean-string-with-spaces
+(deftest ^{:task 1} clean-string-with-spaces
   (is (= "my___Id" (squeaky-clean/clean "my   Id"))))
 
-(deftest ^:task1 clean-string-with-no-letters
+(deftest ^{:task 1} clean-string-with-no-letters
   (is (= "" (squeaky-clean/clean "😀😀😀"))))
 
-(deftest ^:task1 clean-empty-string
+(deftest ^{:task 1} clean-empty-string
   (is (= "" (squeaky-clean/clean ""))))
 
-(deftest ^:task2 clean-string-with-control-char
+(deftest ^{:task 2} clean-string-with-control-char
   (is (= "myCTRLId" (squeaky-clean/clean "my\u0000Id"))))
 
-(deftest ^:task3 convert-kebab-to-camel-case
+(deftest ^{:task 3} convert-kebab-to-camel-case
   (is (= "àḂç" (squeaky-clean/clean "à-ḃç"))))
 
-(deftest ^:task4 omit-lower-case-greek-letters
+(deftest ^{:task 4} omit-lower-case-greek-letters
   (is (= "MyΟFinder" (squeaky-clean/clean "MyΟβιεγτFinder"))))
 
-(deftest ^:task3 combine-conversions
+(deftest ^{:task 3} combine-conversions
   (is (= "_AbcĐCTRL" (squeaky-clean/clean "9 -abcĐ😀ω\0"))))

--- a/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
+++ b/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
@@ -2,25 +2,25 @@
   (:require [clojure.test :refer [deftest is]]
             tracks-on-tracks-on-tracks))
 
-(deftest list-empty-test
+(deftest ^:task1 list-empty-test
   (is (= '() (tracks-on-tracks-on-tracks/new-list))))
 
-(deftest list-add-test
+(deftest ^:task2 list-add-test
   (is (= '("JavaScript" "Java" "Lisp" "Clojure")
          (-> (tracks-on-tracks-on-tracks/new-list)
-              (tracks-on-tracks-on-tracks/add-language "Clojure")
-              (tracks-on-tracks-on-tracks/add-language "Lisp")
-              (tracks-on-tracks-on-tracks/add-language "Java")
-              (tracks-on-tracks-on-tracks/add-language "JavaScript")))))
+             (tracks-on-tracks-on-tracks/add-language "Clojure")
+             (tracks-on-tracks-on-tracks/add-language "Lisp")
+             (tracks-on-tracks-on-tracks/add-language "Java")
+             (tracks-on-tracks-on-tracks/add-language "JavaScript")))))
 
-(deftest first-test
+(deftest ^:task3 first-test
   (is (= "Lisp" (tracks-on-tracks-on-tracks/first-language '("Lisp" "Clojure")))))
 
-(deftest list-remove-test
+(deftest ^:task4 list-remove-test
   (is (= '("Clojure") (tracks-on-tracks-on-tracks/remove-language '("Lisp" "Clojure")))))
 
-(deftest list-count-test
+(deftest ^:task5 list-count-test
   (is (= 3 (tracks-on-tracks-on-tracks/count-languages '("JavaScript" "Java" "Clojure")))))
 
-(deftest learning-list-test
+(deftest ^:task6 learning-list-test
   (is (= 3 (tracks-on-tracks-on-tracks/learning-list))))

--- a/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
+++ b/exercises/concept/tracks-on-tracks-on-tracks/test/tracks_on_tracks_on_tracks_test.clj
@@ -2,10 +2,10 @@
   (:require [clojure.test :refer [deftest is]]
             tracks-on-tracks-on-tracks))
 
-(deftest ^:task1 list-empty-test
+(deftest ^{:task 1} list-empty-test
   (is (= '() (tracks-on-tracks-on-tracks/new-list))))
 
-(deftest ^:task2 list-add-test
+(deftest ^{:task 2} list-add-test
   (is (= '("JavaScript" "Java" "Lisp" "Clojure")
          (-> (tracks-on-tracks-on-tracks/new-list)
              (tracks-on-tracks-on-tracks/add-language "Clojure")
@@ -13,14 +13,14 @@
              (tracks-on-tracks-on-tracks/add-language "Java")
              (tracks-on-tracks-on-tracks/add-language "JavaScript")))))
 
-(deftest ^:task3 first-test
+(deftest ^{:task 3} first-test
   (is (= "Lisp" (tracks-on-tracks-on-tracks/first-language '("Lisp" "Clojure")))))
 
-(deftest ^:task4 list-remove-test
+(deftest ^{:task 4} list-remove-test
   (is (= '("Clojure") (tracks-on-tracks-on-tracks/remove-language '("Lisp" "Clojure")))))
 
-(deftest ^:task5 list-count-test
+(deftest ^{:task 5} list-count-test
   (is (= 3 (tracks-on-tracks-on-tracks/count-languages '("JavaScript" "Java" "Clojure")))))
 
-(deftest ^:task6 learning-list-test
+(deftest ^{:task 6} learning-list-test
   (is (= 3 (tracks-on-tracks-on-tracks/learning-list))))


### PR DESCRIPTION
This PR is an updated version of #434

Sorry for creating a new PR, but I don't have permission to push my changes directly to the existing branch and couldn't see another way.

What I've done:

1. Rebased the existing #434 branch on top of main (since it was quite old) and resolved the merge conflicts
2. Updated the metadata format to match what the test runner will support once exercism/clojure-test-runner#43 is merged
3. Added task metadata to the tests for the only 2 exercises that have task numbers but didn't have metadata yet. I think both are still WIP exercises but doesn't hurt to add the metadata anyway