### PR TITLE
Update elyses_destructured_enchantments.clj

### DIFF
--- a/exercises/concept/elyses-destructured-enchantments/src/elyses_destructured_enchantments.clj
+++ b/exercises/concept/elyses-destructured-enchantments/src/elyses_destructured_enchantments.clj
@@ -16,8 +16,8 @@
 )
 
 (defn discard-top-card
-  "Returns a vector containing the first card and
-   a vector of the remaining cards in the deck."
+  "Returns a sequence containing the first card and
+   a sequence of the remaining cards in the deck."
   [deck]
 )
 


### PR DESCRIPTION
The test suite specifically does not test that the function returns a vector or that the remaining cards are held in a vector. This comment adds pointless complexity to the exercise which is trivially solved using destructuring.