### PR TITLE
Update exemplar.clj

### DIFF
--- a/exercises/concept/elyses-destructured-enchantments/.meta/exemplar.clj
+++ b/exercises/concept/elyses-destructured-enchantments/.meta/exemplar.clj
@@ -2,37 +2,32 @@
 
 (defn first-card
   "Returns the first card from deck."
-  [deck]
-  (let [[first] deck]
-    first))
+  [[card]]
+  card)
 
 (defn second-card
   "Returns the second card from deck."
-  [deck]
-  (let [[_ second] deck]
-    second))
+  [[_ card]]
+  card)
 
 (defn swap-top-two-cards
   "Returns the deck with first two items reversed."
-  [deck]
-  (let [[a b & rest] deck]
-    (vec (conj rest a b))))
+  [[a b & more]]
+  (list* b a more))
 
 (defn discard-top-card
-  "Returns a vector containing the first card and
-   a vector of the remaining cards in the deck."
-  [deck]
-  (let [[first & rest] deck]
-    [first rest]))
+  "Returns a sequence containing the first card and
+   a sequence of the remaining cards in the deck."
+  [[card & more]]
+  [card more])
 
 (def face-cards
   ["jack" "queen" "king"])
 
 (defn insert-face-cards
   "Returns the deck with face cards between its head and tail."
-  [deck]
-  (let [[head & tail] deck]
-    (vec (remove nil? (flatten [head face-cards tail])))))
+  [[head & tail]]
+    (vec (remove nil? (flatten [head face-cards tail]))))
 
 (comment
   (insert-face-cards [3 10 7])


### PR DESCRIPTION
The exemplar solution should not guide students to shadow functions in clojure.core, e.g., first, second, rest. It should also illustrate more straightforward destructuring on function parameters. There is no need for separate let bindings. Finally, the comment in discard-top-card is inconsistent with the test suite. Furthermore, the function does not satisfy the results stated in the doc comment. Namely, the remaining cards are not returned as a vector.