### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -277,7 +277,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "befca7ee-fc29-4ef0-afd7-2d3f68aa47fb",
         "practices": [],
         "prerequisites": ["lists", "numbers", "strings"],
@@ -366,7 +366,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "d8773153-d717-43f1-9324-c7e8cf00455c",
         "practices": [],
         "prerequisites": ["strings"],
@@ -410,7 +410,7 @@
       },
       {
         "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
+        "name": "Run-Length Encoding",
         "uuid": "fa1be98f-59b2-487e-948d-46e744d50dc4",
         "practices": [],
         "prerequisites": ["numbers", "strings"],
@@ -487,7 +487,7 @@
       },
       {
         "slug": "sum-of-multiples",
-        "name": "Sum Of Multiples",
+        "name": "Sum of Multiples",
         "uuid": "357de34a-c149-4a2c-b6a8-86ffb5eaa152",
         "practices": [],
         "prerequisites": ["numbers", "conditionals"],
@@ -641,7 +641,7 @@
       },
       {
         "slug": "isbn-verifier",
-        "name": "Isbn Verifier",
+        "name": "ISBN Verifier",
         "uuid": "0479e73c-acb3-4a36-949c-a2065bfb57e5",
         "practices": [],
         "prerequisites": ["strings", "booleans"],
@@ -685,7 +685,7 @@
       },
       {
         "slug": "pascals-triangle",
-        "name": "Pascals Triangle",
+        "name": "Pascal's Triangle",
         "uuid": "29b16274-b413-4231-a1c7-aff8f93c9b7e",
         "practices": [],
         "prerequisites": ["numbers"],
@@ -784,7 +784,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "6f69d8fe-9da2-48f9-a635-b9f54b626daf",
         "practices": ["numbers"],
         "prerequisites": ["numbers"],
@@ -982,7 +982,7 @@
       },
       {
         "slug": "pov",
-        "name": "Pov",
+        "name": "POV",
         "uuid": "ca557f64-9e2d-4ab0-8788-4133764ef703",
         "practices": [],
         "prerequisites": ["strings", "vectors"],


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579