### PR TITLE
Add test case to sublist exercise failing incorrect use of set operations

### DIFF
--- a/exercises/practice/sublist/test/sublist_test.clj
+++ b/exercises/practice/sublist/test/sublist_test.clj
@@ -52,3 +52,6 @@
 
 (deftest same-digits-but-different-numbers
     (is (= :unequal (sublist/classify [1 0 1] [10 1]))))
+
+(deftest second-list-continues-first-list
+  (is (= :unequal (sublist/classify [1] [2 3]))))


### PR DESCRIPTION
I noticed some solutions to the sublist exercise that look like this:
```clojure
(ns sublist
  (:require [clojure.set :as s]))

(defn classify [list1 list2]
  (cond
    (= list1 list2) :equal
    (s/subset? list1 list2) :sublist
    (s/subset? list2 list1) :superlist
    :else :unequal))
```
This solution passes all the tests but, doesn't work correctly in many cases:
```clojure
(classify [1] [2 3]) ;; should be :unequal
;; => :sublist
(classify [3 4 5] [3 4]) ;; should be :superlist
;; => :unequal
```
This PR adds a test that fails on solutions that use the set module functions this way.