### PR TITLE
Add alternate task 7 test case to bird watcher

### DIFF
--- a/exercises/concept/bird-watcher/test/bird_watcher_test.clj
+++ b/exercises/concept/bird-watcher/test/bird_watcher_test.clj
@@ -49,6 +49,10 @@
   (testing "Odd week for week matching odd pattern"
     (is (= true (bird-watcher/odd-week? [1 0 1 0 1 0 1])))))
 
+(deftest ^{:task 7} odd-week-matching-alternate-test
+  (testing "Odd week for week matching odd pattern"
+    (is (= true (bird-watcher/odd-week? [0 1 0 1 0 1 0])))))
+
 (deftest ^{:task 7} odd-week-not-matching-test
   (testing "Odd week for week that does not match pattern"
     (is (= false (bird-watcher/odd-week? [2 2 1 0 1 1 1])))))


### PR DESCRIPTION
Hi, first of sorry if this is not the correct way to go about this or I'm doing this in a wrong way. I'm new to contributing to exercism (and to contributions on GitHub generally). Anyway...

I've noticed that the following implementations were satisfactory for the 7th task in the bird watcher exercise.
```clj
;; doesn't take into account weeks that start with zero birds
(defn odd-week? [birds]
  (= (take (count birds) (cycle [1 0 ])) birds)) 
  
;; same case as above, but hardcoded
(defn odd-week? [birds]
  (= [1 0 1 0 1 0 1] birds))
```

Maybe I've misunderstood the task/assignment, but I think both `[1 0 1 0 1 0 1]` and `[0 1 0 1 0 1 0]` should result in true.

So I've added an extra test for the second case. LMK if this is fine or if there's some some more changes that should be done (or if I'm wrong altogether :)