### PR TITLE
Add unit test to robot name

### DIFF
--- a/exercises/practice/robot-name/.meta/src/example.clj
+++ b/exercises/practice/robot-name/.meta/src/example.clj
@@ -1,7 +1,8 @@
 (ns robot-name)
 
-(def ^:private letters (map char (range 65 91)))
-(defn- generate-name []
+(def letters (map char (range 65 91)))
+
+(defn generate-name []
   (format "%s%03d" (apply str (repeatedly 2 #(rand-nth letters)))
           (rand-int 1000)))
 

--- a/exercises/practice/robot-name/.meta/src/example.clj
+++ b/exercises/practice/robot-name/.meta/src/example.clj
@@ -1,16 +1,53 @@
-(ns robot-name)
+(ns robot-name
+  (:require [clojure.set :as set]))
 
-(def letters (map char (range 65 91)))
-
-(defn generate-name []
-  (format "%s%03d" (apply str (repeatedly 2 #(rand-nth letters)))
-          (rand-int 1000)))
-
-(defn robot []
-  (atom {:name (generate-name)}))
-
+;; h/t next-mad-hatter: https://exercism.org/tracks/clojure/exercises/robot-name/solutions/next-mad-hatter
+;;
+;; First, note how allowed robot names can be viewed as
+;; mixed-base numbers (two digits in base 26, three in base 10)
+;; between 0 and what is called max-robot-code below.
+;;
+;; We'll call these numbers robot codes to differentiate them from
+;; their string representations (or "names").
+;;
+(def ^:private max-robot-code (+ (* 27 25 1000) 999))
+;;
+;; Above interpretation results in a mapping like this:
+;;
+;; (map code->name [0 1000 25999 26001 max-robot-code])
+;; => ("AA000" "AB000" "AZ999" "BA001" "ZZ999")
+;;
+(defn- code->name [n]
+  (let [part3   (mod n 1000)
+        part2   (mod (int (/ n 1000)) 26)
+        part1   (int (/ n 26000))
+        letter2 (char (+ (int \A) part2))
+        letter1 (char (+ (int \A) part1))]
+    (str letter1 letter2 (format "%03d" part3))))
+;;
+;; Our world contains last code taken along with the set of all currently taken
+;; codes.  Each robot will additionally hold all its previously assigned codes.
+;;
+(def ^:private world (atom [nil #{}]))
+(def ^:private all-codes (set (range (inc max-robot-code))))
+(defn- get-new-code [previous old-code [_ taken]]
+  (let [available (set/difference all-codes taken previous)
+        new-code  (-> available shuffle first)
+        taken'    (-> taken (conj new-code) (disj old-code))]
+    [new-code taken']))
 (defn robot-name [robot]
-  (:name @robot))
-
+  (-> robot :code deref code->name))
 (defn reset-name [robot]
-  (swap! robot assoc :name (generate-name)))
+  (let [old-code     (-> robot :code deref)
+        [new-code _] (swap! world (partial get-new-code (-> robot :previous deref) (-> robot :code deref)))]
+    (assert (some? new-code))
+    (when old-code (swap! (:previous robot) #(conj % old-code)))
+    (reset! (:code robot) new-code)
+    robot))
+(defn robot []
+  (-> {:previous (atom #{}) :code (atom nil)}
+      reset-name))
+(defn previous-names [robot]
+  (->> robot :previous deref (map code->name)))
+(defn current-names []
+  (->> @world second (map code->name)))

--- a/exercises/practice/robot-name/.meta/src/example.clj
+++ b/exercises/practice/robot-name/.meta/src/example.clj
@@ -1,53 +1,39 @@
-(ns robot-name
-  (:require [clojure.set :as set]))
+(ns robot-name)
 
-;; h/t next-mad-hatter: https://exercism.org/tracks/clojure/exercises/robot-name/solutions/next-mad-hatter
-;;
-;; First, note how allowed robot names can be viewed as
-;; mixed-base numbers (two digits in base 26, three in base 10)
-;; between 0 and what is called max-robot-code below.
-;;
-;; We'll call these numbers robot codes to differentiate them from
-;; their string representations (or "names").
-;;
-(def ^:private max-robot-code (+ (* 27 25 1000) 999))
-;;
-;; Above interpretation results in a mapping like this:
-;;
-;; (map code->name [0 1000 25999 26001 max-robot-code])
-;; => ("AA000" "AB000" "AZ999" "BA001" "ZZ999")
-;;
-(defn- code->name [n]
-  (let [part3   (mod n 1000)
-        part2   (mod (int (/ n 1000)) 26)
-        part1   (int (/ n 26000))
-        letter2 (char (+ (int \A) part2))
-        letter1 (char (+ (int \A) part1))]
-    (str letter1 letter2 (format "%03d" part3))))
-;;
-;; Our world contains last code taken along with the set of all currently taken
-;; codes.  Each robot will additionally hold all its previously assigned codes.
-;;
-(def ^:private world (atom [nil #{}]))
-(def ^:private all-codes (set (range (inc max-robot-code))))
-(defn- get-new-code [previous old-code [_ taken]]
-  (let [available (set/difference all-codes taken previous)
-        new-code  (-> available shuffle first)
-        taken'    (-> taken (conj new-code) (disj old-code))]
-    [new-code taken']))
-(defn robot-name [robot]
-  (-> robot :code deref code->name))
-(defn reset-name [robot]
-  (let [old-code     (-> robot :code deref)
-        [new-code _] (swap! world (partial get-new-code (-> robot :previous deref) (-> robot :code deref)))]
-    (assert (some? new-code))
-    (when old-code (swap! (:previous robot) #(conj % old-code)))
-    (reset! (:code robot) new-code)
-    robot))
+(defn letters [] 
+  (let [letter #(rand-nth (map char (range 65 91)))]
+    (apply str (repeatedly 2 letter))))
+
+(defn numbers []
+  (let [number #(rand-int 10)]
+    (apply str (repeatedly 3 number))))
+
+;; Maintain a set of robot names
+
+(def robots (atom #{}))
+
+;; Before returning robot, check if the set count has increased.
+
 (defn robot []
-  (-> {:previous (atom #{}) :code (atom nil)}
-      reset-name))
-(defn previous-names [robot]
-  (->> robot :previous deref (map code->name)))
-(defn current-names []
-  (->> @world second (map code->name)))
+  (let [active-names @robots
+        robot-count (count active-names)
+        new-name (str (letters) (numbers))]
+    (if (< robot-count (count (conj active-names new-name)))
+      (do (swap! robots conj new-name)
+          (atom {:name new-name}))
+      (recur))))
+
+(comment
+  (robot)
+  @robots
+  )
+
+(defn robot-name [robot]
+  (:name @robot))
+ 
+(defn reset-name [robot]
+  (swap! robot assoc :name (str (letters) (numbers))))
+
+(comment
+  (re-seq #"[A-Z]{2}\d{3}" (robot-name (robot)))
+  )

--- a/exercises/practice/robot-name/test/robot_name_test.clj
+++ b/exercises/practice/robot-name/test/robot_name_test.clj
@@ -39,5 +39,5 @@
       (is (= its-new-name (robot-name/robot-name a-robot)))))
 
 (deftest new-names-different-each-time
-  (let [four-thousand-names (repeatedly 4000 #(robot-name/generate-name))]
+  (let [four-thousand-names (repeatedly 4000 #(robot-name/robot-name (robot-name/robot)))]
     (is (= 4000 (count (set four-thousand-names))))))

--- a/exercises/practice/robot-name/test/robot_name_test.clj
+++ b/exercises/practice/robot-name/test/robot_name_test.clj
@@ -39,9 +39,5 @@
       (is (= its-new-name (robot-name/robot-name a-robot)))))
 
 (deftest new-names-different-each-time
-  (let [a-robot (robot-name/robot)
-        its-original-name (robot-name/robot-name a-robot)
-        its-new-name (do (robot-name/reset-name a-robot)
-                         (robot-name/robot-name a-robot))]
-  (is (not= its-new-name (do (robot-name/reset-name a-robot)
-                             (robot-name/robot-name a-robot))))))
+  (let [four-thousand-names (repeatedly 4000 #(robot-name/generate-name))]
+    (is (= 4000 (count (set four-thousand-names))))))


### PR DESCRIPTION
The instructions state:

> Your solution must ensure that every existing robot has a unique name.

However, there was not any test to ensure that the solution satisfies this.