### PR TITLE
update installation instructions for Linux, Mac and Windows

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,13 +3,24 @@
 ## Installing the Clojure CLI
 Clojure provides command line tools that can be used to start a Clojure repl, use Clojure and Java libraries, and start Clojure programs.
 
+If you need to install Java, we recommend [Adoptium Temurin 17](https://adoptium.net/).
+
 ### Linux
-Ensure that the following dependencies are installed: `bash`, `curl`, `rlwrap`, and `Java`.
+Ensure that the following dependencies are installed: `bash`, `curl`, `rlwrap`, and `Java`. 
+You can install Clojure either of these 2 ways:
+
+1. LinuxBrew - requires [Homebrew](https://brew.sh/)
 
 ```bash
-curl -O https://download.clojure.org/install/linux-install-1.10.3.967.sh
-chmod +x linux-install-1.10.3.967.sh
-sudo ./linux-install-1.10.3.967.sh
+brew install clojure/tools/clojure
+```
+
+2. Script installer
+
+```bash
+curl -O https://download.clojure.org/install/linux-install-1.11.1.1347.sh
+chmod +x linux-install-1.11.1.1347.sh
+sudo ./linux-install-1.11.1.1347.sh
 ```
 
 ### Homebrew for Mac OS X
@@ -19,8 +30,23 @@ Install the command line tools with brew from the [clojure/tools](https://github
 brew install clojure/tools/clojure
 ```
 
+#### Java
+
+Any distribution of Java will work. If needed, you can install Temurin using brew:
+
+```bash
+brew tap homebrew/cask-versions
+brew install --cask temurin17
+```
+
 ### Windows
-For running Clojure on Windows it is recommended to use WSL2.
+
+Clojure on Windows has improved significantly recently. We used to recommended using WSL2, which works great,
+but there is now a PowerShell installer. Make sure Java is installed and the `JAVA_HOME` environment variable is set, and run:
+
+```powershell
+iwr -useb download.clojure.org/install/win-install-1.11.1.1165.ps1 | iex
+```
 
 Another way to install Clojure on Windows is with the [Scoop](https://scoop.sh/) package manager. To install scoop, open PowerShell and run these 2 commands, one after the other:
 
@@ -62,3 +88,12 @@ After successfully running steps above, you should be able to run Clojure with t
 ```sh
 clj
 ```
+
+## Install Leiningen (optional)
+
+While no longer necessary, we still support the full featured project management tool [Leiningen](https://leiningen.org/).
+
+1. Download the [lein script](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein) or [lein.bat](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat) (Windows)
+2. Place it on your `$PATH` where your shell can find it (eg. `/usr/local/bin/`)
+3. Set it to be executable (`sudo chmod a+x /usr/local/bin/lein`)
+4. Run `lein`.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -92,6 +92,7 @@ clj
 ## Install Leiningen (optional)
 
 While no longer necessary, we still support the full featured project management tool [Leiningen](https://leiningen.org/).
+It offers a wide variety of helpful tasks like convenient testing, builds, and an improved REPL.
 
 1. Download the [lein script](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein) or [lein.bat](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat) (Windows)
 2. Place it on your `$PATH` where your shell can find it (eg. `/usr/local/bin/`)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -53,7 +53,7 @@ Another way to install Clojure on Windows is with the [Scoop](https://scoop.sh/)
  ```sh
  iwr -useb get.scoop.sh | iex
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-``
+```
 
 To install Clojure with Scoop you have to add two important buckets first:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -98,3 +98,14 @@ It offers a wide variety of helpful tasks like convenient testing, builds, and a
 2. Place it on your `$PATH` where your shell can find it (eg. `/usr/local/bin/`)
 3. Set it to be executable (`sudo chmod a+x /usr/local/bin/lein`)
 4. Run `lein`.
+
+## Editor integration
+
+The best way to develop Clojure is with an editor-connected REPL. Plugins are available for the most popular editors/IDEs:
+
+- Emacs: [CIDER](https://cider.mx/)
+- IntelliJ: [Cursive](https://cursive-ide.com/)
+- VSCode: [Calva](https://calva.io/)
+- Vim: [Conjure](https://github.com/Olical/conjure)
+
+See the [official docs](https://clojure.org/guides/editors) for more info.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -42,7 +42,9 @@ brew install --cask temurin17
 ### Windows
 
 Clojure on Windows has improved significantly recently. We used to recommended using WSL2, which works great,
-but there is now a PowerShell installer. Make sure Java is installed and the `JAVA_HOME` environment variable is set, and run:
+but there is now a PowerShell installer. Clojure on Windows is currently in an alpha state, see [clj-on-windows](https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows#known-issues) for known issues.
+
+Make sure Java is installed and the `JAVA_HOME` environment variable is set, and run:
 
 ```powershell
 iwr -useb download.clojure.org/install/win-install-1.11.1.1165.ps1 | iex

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -2,15 +2,18 @@
 
 ## Project Structure
 
-Clojure exercises in exercism use [leiningen](http://leiningen.org/) to configure and run your code
-and use [leiningen standard directory structure](https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md#directory-layout).
+Clojure exercises in exercism support the two most common tools for dependency management and testing, [leiningen](http://leiningen.org/) and the [Clojure CLI](https://clojure.org/guides/deps_and_cli).
 
 You will find a test file named `hello_world_test.clj` inside `test` directory.
 Write your code in `src/hello_world.clj`. It should use the namespace `hello-world` so that tests can pick it up.
 
-## Running tests
+### Running tests using the Clojure CLI
 
-Run the tests using `lein test` command and make them pass:
+```
+$ clj -X:test
+```
+
+### Running tests using Leiningen
 
 ```
 $ lein test


### PR DESCRIPTION
Also included, by request, instructions for installing the Leiningen tool.

Linux: added instructions for LinuxBrew, bumped Clojure version
Mac: Added instructions for installing Temurin Java
Windows: Include new PowerShell installer

Also included a bit for common editor/IDE plugins.

Added instructions for testing with the Clojure CLI on the `hello-world` page.