### PR TITLE
Interest is interesting: Update exemplar solution to use built-in function abs from Clojure 1.11

### DIFF
--- a/exercises/concept/interest-is-interesting/.meta/exemplar.clj
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.clj
@@ -10,7 +10,7 @@
 (defn- annual-yield [balance]
   (let [multiplier (bigdec (/ (interest-rate balance)
                               100))]
-    (* (if (neg? balance) (- balance) balance) multiplier)))
+    (* (abs balance) multiplier)))
 
 (defn annual-balance-update [balance]
   (+ balance (annual-yield balance)))

--- a/exercises/concept/interest-is-interesting/project.clj
+++ b/exercises/concept/interest-is-interesting/project.clj
@@ -1,4 +1,4 @@
 (defproject interest-is-interesting "0.1.0-SNAPSHOT"
   :description "interest-is-interesting exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/interest-is-interesting"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/interest-is-interesting/src/interest_is_interesting.clj
+++ b/exercises/concept/interest-is-interesting/src/interest_is_interesting.clj
@@ -1,16 +1,16 @@
 (ns interest-is-interesting)
 
 (defn interest-rate
-  "TODO: add docstring"
+  "Returns the interest rate based on the specified balance."
   [balance]
   )
 
 (defn annual-balance-update
-  "TODO: add docstring"
+  "Returns the annual balance update, taking into account the interest rate."
   [balance]
   )
 
 (defn amount-to-donate
-  "TODO: add docstring"
+  "Returns how much money to donate based on the balance and the tax-free percentage."
   [balance tax-free-percentage]
   )


### PR DESCRIPTION
Clojure 1.11 added an `abs` function that we can now use instead of defining our own function or `Math/abs`.

I've also replaced the TODO in docstrings. This is just a copy-paste from the problem description. Feel free to edit them if needed.