### PR TITLE
Squeaky clean: Use different control chars

### DIFF
--- a/exercises/concept/squeaky-clean/.docs/instructions.md
+++ b/exercises/concept/squeaky-clean/.docs/instructions.md
@@ -32,7 +32,7 @@ its code is in the range '\u0000' through '\u001F'
 or in the range '\u007F' through '\u009F'.
 
 ```clojure
-(clean "my\0Id")
+(clean "my\u007FId")
 ;;=> "myCTRLId"
 ```
 

--- a/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
+++ b/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
@@ -15,7 +15,7 @@
   (is (= "" (squeaky-clean/clean ""))))
 
 (deftest ^{:task 2} clean-string-with-control-char
-  (is (= "myCTRLId" (squeaky-clean/clean "my\u0000Id"))))
+  (is (= "myCTRLId" (squeaky-clean/clean "my\u0080Id"))))
 
 (deftest ^{:task 3} convert-kebab-to-camel-case
   (is (= "àḂç" (squeaky-clean/clean "à-ḃç"))))


### PR DESCRIPTION
The string "my\0Id" works fine in Java, but isn't parsed at all in Clojure. I've replaced it with a proper unicode sequence.

Another thing i've noticed is that some people use something like `#"\p{Cntrl}"` as a regex that cleans the control chars. This regex looks fine, but it's not. It covers the first range `u0000-\u001F` and only the first char from the second range `\u007F-\u009F`. Obviously those people didn't even consider the possibility of that regex not covering everything.

Should we replace the control char in tests with a different one? If so, i'll do it in this PR.