### PR TITLE
Armstrong numbers: Sync with problem-specifications

### DIFF
--- a/exercises/practice/armstrong-numbers/.docs/instructions.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
 
 For example:
 
@@ -10,3 +10,5 @@ For example:
 - 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
 
 Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -20,7 +20,7 @@
       ".meta/src/example.clj"
     ]
   },
-  "blurb": "Determine if a number is an Armstrong number",
+  "blurb": "Determine if a number is an Armstrong number.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
 }

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,30 +1,45 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
-description = "Single digit numbers are Armstrong numbers"
+description = "Single-digit numbers are Armstrong numbers"
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
-description = "There are no 2 digit Armstrong numbers"
+description = "There are no two-digit Armstrong numbers"
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
-description = "Three digit number that is an Armstrong number"
+description = "Three-digit number that is an Armstrong number"
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
-description = "Three digit number that is not an Armstrong number"
+description = "Three-digit number that is not an Armstrong number"
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
-description = "Four digit number that is an Armstrong number"
+description = "Four-digit number that is an Armstrong number"
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
-description = "Four digit number that is not an Armstrong number"
+description = "Four-digit number that is not an Armstrong number"
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
-description = "Seven digit number that is an Armstrong number"
+description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
-description = "Seven digit number that is not an Armstrong number"
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+include = false
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"
+include = false

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -7,37 +7,33 @@
     (is (armstrong? 0))))
 
 (deftest armstrong-number-5
-  (testing "Single digit numbers are Armstrong numbers"
+  (testing "Single-digit numbers are Armstrong numbers"
     (is (armstrong? 5))))
 
 (deftest not-armstrong-number-10
-  (testing "There are no 2 digit Armstrong numbers"
+  (testing "There are no two-digit Armstrong numbers"
     (is (not (armstrong? 10)))))
 
 (deftest armstrong-number-153
-  (testing "Three digit number that is an Armstrong number"
+  (testing "Three-digit number that is an Armstrong number"
     (is (armstrong? 153))))
 
 (deftest not-armstrong-number-100
-  (testing "Three digit number that is not an Armstrong number"
+  (testing "Three-digit number that is not an Armstrong number"
     (is (not (armstrong? 100)))))
 
 (deftest armstrong-number-9474
-  (testing "Four digit number that is an Armstrong number"
+  (testing "Four-digit number that is an Armstrong number"
     (is (armstrong? 9474))))
 
 (deftest not-armstrong-number-9475
-  (testing "Four digit number that is not an Armstrong number"
+  (testing "Four-digit number that is not an Armstrong number"
     (is (not (armstrong? 9475)))))
 
 (deftest armstrong-number-9926315
-  (testing "Seven digit number that is an Armstrong number"
+  (testing "Seven-digit number that is an Armstrong number"
     (is (armstrong? 9926315))))
 
 (deftest not-armstrong-number-9926314
-  (testing "Seven digit number that is not an Armstrong number"
+  (testing "Seven-digit number that is not an Armstrong number"
     (is (not (armstrong? 9926314)))))
-
-(deftest armstrong-number-21897142587612075
-  (testing "Seventeen digit number that is an Armstrong number"
-    (is (armstrong? 21897142587612075))))


### PR DESCRIPTION
The updated tests from problem specifications require solutions that use big integers. While this can be easily done in Clojure, those tests were left out to avoid breaking existing solutions.