### PR TITLE
Activate Card Games exercise, deprecate Tracks on Tracks on Tracks

### DIFF
--- a/config.json
+++ b/config.json
@@ -48,12 +48,8 @@
         "slug": "tracks-on-tracks-on-tracks",
         "name": "Tracks on Tracks on Tracks",
         "uuid": "0d05620f-3ef9-43aa-8e89-660187e090f3",
-        "concepts": [
-          "lists"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": [],
+        "prerequisites": [],
         "status": "deprecated"
       },
       {

--- a/config.json
+++ b/config.json
@@ -54,7 +54,7 @@
         "prerequisites": [
           "basics"
         ],
-        "status": "beta"
+        "status": "deprecated"
       },
       {
         "slug": "bird-watcher",
@@ -168,7 +168,7 @@
         "uuid": "01a06d2b-ffb1-4497-9bb3-d93ee2d0931b",
         "concepts": ["lists"],
         "prerequisites": ["basics", "conditionals", "booleans"],
-        "status": "wip"
+        "status": "beta"
       }
     ],
     "practice": [


### PR DESCRIPTION
I'm really going to miss typing that one. /s
Whose idea was it to name it that, anyway?

The lists exercise, Tracks... was problematic for three reasons:

1. The entire exercise except for the final task involved writing functions that did nothing but wrap clojure core functions like `first`, `last`, etc.
2. The final task really had nothing to do with lists but rather involved function composition. It also could not be ergonomically solved without using a threading macro which the student would not presumably know at that point.
3. It has an unreasonably long name.

This exercise is considerably harder, but puts the lists concept ahead in the syllabus because it has conditionals and booleans as prerequisites.