### PR TITLE
Change Bank Account prerequisites/practices

### DIFF
--- a/config.json
+++ b/config.json
@@ -930,8 +930,8 @@
         "slug": "bank-account",
         "name": "Bank Account",
         "uuid": "d67a7a46-050c-4472-84bd-2e216079a452",
-        "practices": ["floating-point-numbers"],
-        "prerequisites": ["floating-point-numbers"],
+        "practices": [],
+        "prerequisites": ["conditionals", "numbers"],
         "difficulty": 7,
         "topics": [
           "conditionals"


### PR DESCRIPTION
Fixes #550.

Prerequisites for Bank Account changed to "conditionals" and "numbers", which matches what other tracks have selected for this exercise.

Even that might be overkill, because the Clojure solution actually requires neither of those...

For reference, here is the example solution:

```clojure
(defn open-account []
  (atom 0))

(defn close-account [acct]
  (reset! acct nil))

(defn get-balance [acct]
  @acct)

(defn update-balance [account amount]
  (swap! account + amount))
```

Still, I think it's probably appropriate to have *some* prerequisites to prevent the student from encountering this exercise too early, before they would reasonably be introduced to atoms, which don't yet have a concept exercise. In any case, this is an improvement because the exercise *definitely* has nothing to do with floating point.