### PR TITLE
Cars-assemble: fix tests failing due to floating point precision

### DIFF
--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -2,29 +2,33 @@
   (:require cars-assemble
             [clojure.test :refer [deftest is testing]]))
 
+(defn- float-equal?
+  [x y]
+  (= (float x) (float y)))
+
 (deftest ^{:task 1} production-rate-speed-0-test
   (testing "Production rate for speed 0"
-    (is (= 0.0 (cars-assemble/production-rate 0)))))
+    (is (float-equal? 0.0 (cars-assemble/production-rate 0)))))
 
 (deftest ^{:task 1} production-rate-speed-1-test
   (testing "Production rate for speed 1"
-    (is (= 221.0 (cars-assemble/production-rate 1)))))
+    (is (float-equal? 221.0 (cars-assemble/production-rate 1)))))
 
 (deftest ^{:task 1} production-rate-speed-4-test
   (testing "Production rate for speed 4"
-    (is (= 884.0 (cars-assemble/production-rate 4)))))
+    (is (float-equal? 884.0 (cars-assemble/production-rate 4)))))
 
-(deftest ^{:task 1} production-rate-speed-7-test
+(deftest ^{:task 1} production-rate-speeed-7-test
   (testing "Production rate for speed 7"
-    (is (= 1392.3 (cars-assemble/production-rate 7)))))
+    (is (float-equal? 1392.3 (cars-assemble/production-rate 7)))))
 
 (deftest ^{:task 1} production-rate-speed-9-test
   (testing "Production rate for speed 9"
-    (is (= 1591.2 (cars-assemble/production-rate 9)))))
+    (is (float-equal? 1591.2 (cars-assemble/production-rate 9)))))
 
 (deftest ^{:task 1} production-rate-speed-10-test
   (testing "Production rate for speed 10"
-    (is (= 1701.7 (cars-assemble/production-rate 10)))))
+    (is (float-equal? 1701.7 (cars-assemble/production-rate 10)))))
 
 (deftest ^{:task 2} working-items-speed-0-test
   (testing "Working items for speed 0"

--- a/exercises/concept/cars-assemble/test/cars_assemble_test.clj
+++ b/exercises/concept/cars-assemble/test/cars_assemble_test.clj
@@ -18,7 +18,7 @@
   (testing "Production rate for speed 4"
     (is (float-equal? 884.0 (cars-assemble/production-rate 4)))))
 
-(deftest ^{:task 1} production-rate-speeed-7-test
+(deftest ^{:task 1} production-rate-speed-7-test
   (testing "Production rate for speed 7"
     (is (float-equal? 1392.3 (cars-assemble/production-rate 7)))))
 


### PR DESCRIPTION
A simple fix for the issue described below:

https://forum.exercism.org/t/cant-solve-cars-assemble-because-of-floating-point-precision/9242

The current tests check if two double numbers x, y are equal, and as a result some of them are failing when the numbers aren't identical. Two possible solutions: 
* Check if the two numbers are close enough using a check like `abs(x-y)<epsilon`.
* Truncate doubles to floats. This lowers the required precision required for the tests to pass.

This PR employs the second approach.