### PR TITLE
x:rep/small - Add test for remaining-time function

### DIFF
--- a/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
+++ b/exercises/concept/lucians-luscious-lasagna/test/lucians_luscious_lasagna_test.clj
@@ -5,7 +5,10 @@
 (deftest ^{:task 1} expected-time-test
   (is (= 40 lucians-luscious-lasagna/expected-time)))
 
-(deftest ^{:task 2} remaining-time-test
+(deftest ^{:task 2} remaining-time-test-for30m-actualtime
+  (is (= 10 (lucians-luscious-lasagna/remaining-time 30))))
+
+(deftest ^{:task 2} remaining-time-test-for25m-actualtime
   (is (= 15 (lucians-luscious-lasagna/remaining-time 25))))
 
 (deftest ^{:task 3} prep-time-one-layer-test


### PR DESCRIPTION
This pull request introduces a new test case for the `remaining_time` function. 
This additional test complements the existing one and verifies the function's logic operates as intended, not just a fixed subtraction or hardcoding.

You can refer to the bellow image to see how the faulty implementation is making all the test cases pass
<img width="1792" alt="Screenshot 2024-05-14 at 6 43 10 PM" src="https://github.com/exercism/clojure/assets/130471241/0aed1b7e-bff8-4d4a-b4b8-57862d6c5692">
