### PR TITLE
card-games: fix typo

### DIFF
--- a/exercises/concept/card-games/.docs/introduction.md
+++ b/exercises/concept/card-games/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-In Clojure, Lists are [collections][type-collection], just as like [lists in other languages][type-list]. Similar to other languages in the Lisp family, Clojure uses parentheses to express lists.
+In Clojure, Lists are [collections][type-collection], just like [lists in other languages][type-list]. Similar to other languages in the Lisp family, Clojure uses parentheses to express lists.
 
 Clojure lists can be created in one of two ways. The `list` function can create a list, or you can `quote` a literal list.
 


### PR DESCRIPTION
Fix a minor error in the introduction to the Card Games exercise