### PR TITLE
squeaky-clean: Update docs

### DIFF
--- a/exercises/concept/squeaky-clean/.docs/hints.md
+++ b/exercises/concept/squeaky-clean/.docs/hints.md
@@ -17,9 +17,9 @@ If it contains no hyphens, you should return it as it is. You can check this usi
 
 You can filter characters using [`Character/isLetter`][java-isletter] as a predicate.
 
-## 5. Omit Greek lower case letters
+## 5. Omit Greek lowercase letters
 
-The lower-case Greek letters are Unicode points `\u03B1` to `\u03C9`, or integer values 945 through 969.
+The Greek lowercase letters are Unicode points `\u03B1` to `\u03C9`, or integer values 945 through 969.
 
 [str-join]: https://clojuredocs.org/clojure.string/join
 [str-upper-case]: https://clojuredocs.org/clojure.string/upper-case

--- a/exercises/concept/squeaky-clean/.docs/hints.md
+++ b/exercises/concept/squeaky-clean/.docs/hints.md
@@ -6,12 +6,12 @@ The built-in `clojure.string` library contains a [`replace`][str-replace] functi
 
 ## 2. Replace control characters with the upper case string "CTRL"
 
-Here we need to use the [`isISOControl`][java-ctrl] method from Java's `Character` class.
+You can use the [`isISOControl`][java-ctrl] method from Java's `Character` class.
 
 ## 3. Convert kebab-case to camelCase
 
 Try separating the string on the hyphens with [`split`][str-split].
-If there are no hyphens, we need to pass the original string. You can check using [`includes?`][str-includes]. Use [`upper-case`][str-upper-case] to make the "humps" of the camel. Finally, concatenate them with [`join`][str-join].
+If it contains no hyphens, you should return it as it is. You can check this using [`includes?`][str-includes]. Use [`upper-case`][str-upper-case] to make the "humps" of the camel. Finally, concatenate them with [`join`][str-join].
 
 ## 4. Omit characters that are not letters
 

--- a/exercises/concept/squeaky-clean/.docs/hints.md
+++ b/exercises/concept/squeaky-clean/.docs/hints.md
@@ -11,11 +11,11 @@ Here we need to use the [`isISOControl`][java-ctrl] method from Java's `Characte
 ## 3. Convert kebab-case to camelCase
 
 Try separating the string on the hyphens with [`split`][str-split].
-If there are no hyphens, we need to pass the original string. You can check using [includes?][str-includes]. Use [upper-case][str-upper-case] to make the "humps" of the camel. Finally, concatenate them with [join][str-join].
+If there are no hyphens, we need to pass the original string. You can check using [`includes?`][str-includes]. Use [`upper-case`][str-upper-case] to make the "humps" of the camel. Finally, concatenate them with [`join`][str-join].
 
 ## 4. Omit characters that are not letters
 
-You can filter characters using [Character/isLetter][java-isletter] as a predicate.
+You can filter characters using [`Character/isLetter`][java-isletter] as a predicate.
 
 ## 5. Omit Greek lower case letters
 

--- a/exercises/concept/squeaky-clean/.docs/hints.md
+++ b/exercises/concept/squeaky-clean/.docs/hints.md
@@ -10,8 +10,8 @@ Here we need to use the [`isISOControl`][java-ctrl] method from Java's `Characte
 
 ## 3. Convert kebab-case to camelCase
 
-Try separating the string on the hyphens with [`string/split`][str-split].
-If there are no hyphens, we need to pass the original string. You can check using [string/includes?][str-includes]. Use [string/upper-case][str-upper-case] to make the "humps" of the camel. Finally, concatenate them with [string/join][str-join].
+Try separating the string on the hyphens with [`split`][str-split].
+If there are no hyphens, we need to pass the original string. You can check using [includes?][str-includes]. Use [upper-case][str-upper-case] to make the "humps" of the camel. Finally, concatenate them with [join][str-join].
 
 ## 4. Omit characters that are not letters
 

--- a/exercises/concept/squeaky-clean/.docs/instructions.md
+++ b/exercises/concept/squeaky-clean/.docs/instructions.md
@@ -3,14 +3,14 @@
 In this exercise you will implement a partial set of utility routines 
 to help a developer clean up identifier names.
 
-In the 5 tasks you will gradually build up the routine `clean`. 
+In the 5 tasks you will gradually build up the function `clean`.
 A valid identifier comprises zero or more letters and underscores.
 
 In all cases the input string is guaranteed to be non-nil. 
-If an empty string is passed to the `clean` function, 
+If an empty string is passed to the function,
 an empty string should be returned.
 
-Note that the caller should avoid calling the routine `clean` 
+Note that the caller should avoid calling the function
 with an empty identifier since such identifiers are ineffectual.
 
 ## 1. Replace any spaces encountered with underscores

--- a/exercises/concept/squeaky-clean/.docs/instructions.md
+++ b/exercises/concept/squeaky-clean/.docs/instructions.md
@@ -55,7 +55,7 @@ Note: The underscores must be preserved from the previous step.
 ;; => ""
 ```
 
-## 5. Omit Greek lower case letters
+## 5. Omit Greek lowercase letters
 
 Modify the `clean` function to omit any Greek letters in the range 'α' to 'ω'.
 


### PR DESCRIPTION
This PR primarily fixes incorrect references to functions from the `clojure.string` namespace, such as `string/join`.

Additionally, I've edited and reworded certain parts to improve flow and maintain consistency.

Edit: In the third commit, the word 'need' was replaced to make it clearer that what follows are only suggestions.