### PR TITLE
annalyns-infiltration: Update docs

### DIFF
--- a/exercises/concept/annalyns-infiltration/.docs/hints.md
+++ b/exercises/concept/annalyns-infiltration/.docs/hints.md
@@ -6,11 +6,11 @@ We need to check if the knight is awake and _invert_ its truth value. This can b
 
 ## 2. Check if the group can be spied upon
 
-We want the function to return `true` if _any_ of the supplied predicates are true. This can be done using the [`or`][or] function.
+We want the function to return `true` if _any_ of the supplied predicates are `true`. This can be done using the [`or`][or] function.
 
 ## 3. Check if the prisoner can be signalled
 
-We want to return `true` if and only if _all_ of the supplied predicates are truthy. This can be done with the [`and`][and] function.
+We want to return `true` if and only if _all_ of the supplied predicates are `true`. This can be done with the [`and`][and] function.
 
 ## 4. Check if the prisoner can be freed
 

--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -20,7 +20,7 @@ You have four tasks: to implement the logic for determining if the above actions
 
 ## 1. Check if a fast attack can be made
 
-Implement the `can-fast-attack?` function that takes a boolean value that indicates if the knight is awake. This function returns `true` if a fast attack can be made based on the state of the knight. Otherwise, it returns `false`:
+Implement the `can-fast-attack?` function, which takes a boolean value indicating whether the knight is awake. The function returns `true` if a fast attack can be made based on the state of the knight. Otherwise, it returns `false`:
 
 ```clojure
 (def knight-awake? true)
@@ -31,7 +31,7 @@ Implement the `can-fast-attack?` function that takes a boolean value that indica
 
 ## 2. Check if the group can be spied upon
 
-Implement the `can-spy?` function that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the group can be spied upon, based on the state of the three characters. Otherwise, it returns `false`:
+Implement the `can-spy?` function, which takes three boolean values indicating whether the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the group can be spied upon based on the state of the three characters. Otherwise, it returns `false`:
 
 ```clojure
 (def knight-awake? false)
@@ -44,7 +44,7 @@ Implement the `can-spy?` function that takes three boolean values, indicating if
 
 ## 3. Check if the prisoner can be signalled
 
-Implement the `can-signal-prisoner?` function that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The function returns `true` if the prisoner can be signalled, based on the state of the two characters. Otherwise, it returns `false`:
+Implement the `can-signal-prisoner?` function, which takes two boolean values indicating whether the archer and the prisoner, respectively, are awake. The function returns `true` if the prisoner can be signalled based on the state of the two characters. Otherwise, it returns `false`:
 
 ```clojure
 (def archer-awake? false)
@@ -56,7 +56,7 @@ Implement the `can-signal-prisoner?` function that takes two boolean values, ind
 
 ## 4. Check if the prisoner can be freed
 
-Implement the `can-free-prisoner?` function that takes four boolean values. The first three parameters indicate if the knight, archer and the prisoner, respectively, are awake. The last parameter indicates if Annalyn's pet dog is present. The function returns `true` if the prisoner can be freed based on the state of the three characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
+Implement the `can-free-prisoner?` function, which takes four boolean values. The first three parameters indicate whether the knight, archer and the prisoner, respectively, are awake. The last parameter indicates whether Annalyn's pet dog is present. The function returns `true` if the prisoner can be freed based on the state of the three characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
 
 ```clojure
 (def knight-awake? false)

--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -20,7 +20,7 @@ You have four tasks: to implement the logic for determining if the above actions
 
 ## 1. Check if a fast attack can be made
 
-Implement the `can-fast-attack?` function that takes a boolean value that indicates if the knight is awake. This function returns `true` if a fast attack can be made based on the state of the knight. Otherwise, returns `false`:
+Implement the `can-fast-attack?` function that takes a boolean value that indicates if the knight is awake. This function returns `true` if a fast attack can be made based on the state of the knight. Otherwise, it returns `false`:
 
 ```clojure
 (def knight-awake? true)
@@ -31,7 +31,7 @@ Implement the `can-fast-attack?` function that takes a boolean value that indica
 
 ## 2. Check if the group can be spied upon
 
-Implement the `can-spy?` function that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the group can be spied upon, based on the state of the three characters. Otherwise, returns `false`:
+Implement the `can-spy?` function that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the group can be spied upon, based on the state of the three characters. Otherwise, it returns `false`:
 
 ```clojure
 (def knight-awake? false)
@@ -44,7 +44,7 @@ Implement the `can-spy?` function that takes three boolean values, indicating if
 
 ## 3. Check if the prisoner can be signalled
 
-Implement the `can-signal-prisoner?` function that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The function returns `true` if the prisoner can be signalled, based on the state of the two characters. Otherwise, returns `false`:
+Implement the `can-signal-prisoner?` function that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The function returns `true` if the prisoner can be signalled, based on the state of the two characters. Otherwise, it returns `false`:
 
 ```clojure
 (def archer-awake? false)

--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md
@@ -2,6 +2,6 @@
 
 Booleans in Clojure are represented by `true` or `false`.
 
-Predicate functions (functions which return a boolean) will typically end with a quesion mark (`?`), but this is by convention only.
+Predicate functions (functions which return a boolean) will typically end with a question mark (`?`), but this is by convention only.
 
 The core library includes functions for logical operators such as `not`, `and`, and `or`.


### PR DESCRIPTION
This PR primarily fixes an issue with an incorrect hint. It should explicitly state `true` instead of 'truthy'.

Edit: Changed 'that' to 'which', given the context (adding extra detail about something already clear)

Edit: Changed 'if' to 'whether', given the context (presenting two implied alternatives)