### PR TITLE
kindergarten-garden: Sync tests

### DIFF
--- a/exercises/practice/kindergarten-garden/.meta/tests.toml
+++ b/exercises/practice/kindergarten-garden/.meta/tests.toml
@@ -1,30 +1,61 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [1fc316ed-17ab-4fba-88ef-3ae78296b692]
-description = "garden with single student"
+description = "partial garden -> garden with single student"
 
 [acd19dc1-2200-4317-bc2a-08f021276b40]
-description = "different garden with single student"
+description = "partial garden -> different garden with single student"
 
 [c376fcc8-349c-446c-94b0-903947315757]
-description = "garden with two students"
+description = "partial garden -> garden with two students"
 
 [2d620f45-9617-4924-9d27-751c80d17db9]
-description = "second student's garden"
+description = "partial garden -> multiple students for the same garden with three students -> second student's garden"
 
 [57712331-4896-4364-89f8-576421d69c44]
-description = "third student's garden"
+description = "partial garden -> multiple students for the same garden with three students -> third student's garden"
 
 [149b4290-58e1-40f2-8ae4-8b87c46e765b]
-description = "first student's garden"
+description = "full garden -> for Alice, first student's garden"
 
 [ba25dbbc-10bd-4a37-b18e-f89ecd098a5e]
-description = "second student's garden"
+description = "full garden -> for Bob, second student's garden"
+
+[566b621b-f18e-4c5f-873e-be30544b838c]
+description = "full garden -> for Charlie"
+
+[3ad3df57-dd98-46fc-9269-1877abf612aa]
+description = "full garden -> for David"
+
+[0f0a55d1-9710-46ed-a0eb-399ba8c72db2]
+description = "full garden -> for Eve"
+
+[a7e80c90-b140-4ea1-aee3-f4625365c9a4]
+description = "full garden -> for Fred"
+
+[9d94b273-2933-471b-86e8-dba68694c615]
+description = "full garden -> for Ginny"
+
+[f55bc6c2-ade8-4844-87c4-87196f1b7258]
+description = "full garden -> for Harriet"
+
+[759070a3-1bb1-4dd4-be2c-7cce1d7679ae]
+description = "full garden -> for Ileana"
+
+[78578123-2755-4d4a-9c7d-e985b8dda1c6]
+description = "full garden -> for Joseph"
 
 [6bb66df7-f433-41ab-aec2-3ead6e99f65b]
-description = "second to last student's garden"
+description = "full garden -> for Kincaid, second to last student's garden"
 
 [d7edec11-6488-418a-94e6-ed509e0fa7eb]
-description = "last student's garden"
+description = "full garden -> for Larry, last student's garden"

--- a/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.clj
+++ b/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.clj
@@ -1,47 +1,88 @@
 (ns kindergarten-garden-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest testing is]]
             kindergarten-garden))
 
-(deftest garden-test
-  (is (= [:radishes :clover :grass :grass]
-         (:alice (kindergarten-garden/garden "RC\nGG"))))
-  (is (= [:violets :clover :radishes :clover]
-         (:alice (kindergarten-garden/garden "VC\nRC")))))
+(deftest test-1fc316ed-17ab-4fba-88ef-3ae78296b692
+  (testing "Partial garden -> Garden with single student"
+    (is (= [:radishes :clover :grass :grass]
+           (:alice (kindergarten-garden/garden "RC\nGG"))))))
 
-(deftest small-garden-test
-  (let [small-garden (kindergarten-garden/garden "VVCG\nVVRC")]
-    (is (= [:clover :grass :radishes :clover] (:bob small-garden)))))
+(deftest test-acd19dc1-2200-4317-bc2a-08f021276b40
+  (testing "Partial garden -> Different garden with single student"
+    (is (= [:violets :clover :radishes :clover]
+           (:alice (kindergarten-garden/garden "VC\nRC"))))))
 
-(deftest medium-garden-test
-  (let [medium-garden (kindergarten-garden/garden "VVCCGG\nVVCCGG")]
-    (is (= [:clover :clover :clover :clover] (:bob medium-garden)))
-    (is (= [:grass :grass :grass :grass] (:charlie medium-garden)))))
+(deftest test-c376fcc8-349c-446c-94b0-903947315757
+  (testing "Partial garden -> Garden with two students"
+    (is (= [:clover :grass :radishes :clover]
+           (:bob (kindergarten-garden/garden "VVCG\nVVRC"))))))
 
-(deftest full-garden-test
-  (let [string "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
-        full-garden (kindergarten-garden/garden string)]
-    (is (= [:violets  :radishes :violets  :radishes] (:alice   full-garden)))
-    (is (= [:clover   :grass    :clover   :clover]   (:bob     full-garden)))
-    (is (= [:violets  :violets  :clover   :grass]    (:charlie full-garden)))
-    (is (= [:radishes :violets  :clover   :radishes] (:david   full-garden)))
-    (is (= [:clover   :grass    :radishes :grass]    (:eve     full-garden)))
-    (is (= [:grass    :clover   :violets  :clover]   (:fred    full-garden)))
-    (is (= [:clover   :grass    :grass    :clover]   (:ginny   full-garden)))
-    (is (= [:violets  :radishes :radishes :violets]  (:harriet full-garden)))
-    (is (= [:grass    :clover   :violets  :clover]   (:ileana  full-garden)))
-    (is (= [:violets  :clover   :violets  :grass]    (:joseph  full-garden)))
-    (is (= [:grass    :clover   :clover   :grass]    (:kincaid full-garden)))
-    (is (= [:grass    :violets  :clover   :violets]  (:larry   full-garden)))))
+(deftest test-2d620f45-9617-4924-9d27-751c80d17db9
+  (testing "Partial garden -> Multiple students for the same garden with three students -> Second student's garden"
+    (is (= [:clover :clover :clover :clover]
+           (:bob (kindergarten-garden/garden "VVCCGG\nVVCCGG"))))))
 
-(deftest surprise-garden-test
-  (let [string   "VCRRGVRG\nRVGCCGCV"
-        students ["Samantha" "Patricia" "Xander" "Roger"]
-        surprise-garden (kindergarten-garden/garden string students)]
-    (is (= [:violets  :clover   :radishes :violets]
-           (:patricia surprise-garden)))
-    (is (= [:radishes :radishes :grass    :clover]
-           (:roger    surprise-garden)))
-    (is (= [:grass    :violets  :clover   :grass]
-           (:samantha surprise-garden)))
-    (is (= [:radishes :grass    :clover   :violets]
-           (:xander   surprise-garden)))))
+(deftest test-57712331-4896-4364-89f8-576421d69c44
+  (testing "Partial garden -> Multiple students for the same garden with three students -> Third student's garden"
+    (is (= [:grass :grass :grass :grass]
+           (:charlie (kindergarten-garden/garden "VVCCGG\nVVCCGG"))))))
+
+(deftest test-149b4290-58e1-40f2-8ae4-8b87c46e765b
+  (testing "Full garden -> For Alice first student's garden"
+    (is (= [:violets :radishes :violets :radishes]
+           (:alice (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-ba25dbbc-10bd-4a37-b18e-f89ecd098a5e
+  (testing "Full garden -> For Bob second student's garden"
+    (is (= [:clover :grass :clover :clover]
+           (:bob (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-566b621b-f18e-4c5f-873e-be30544b838c
+  (testing "Full garden -> For Charlie"
+    (is (= [:violets :violets :clover :grass]
+           (:charlie (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-3ad3df57-dd98-46fc-9269-1877abf612aa
+  (testing "Full garden -> For David"
+    (is (= [:radishes :violets :clover :radishes]
+           (:david (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-0f0a55d1-9710-46ed-a0eb-399ba8c72db2
+  (testing "Full garden -> For Eve"
+    (is (= [:clover :grass :radishes :grass]
+           (:eve (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-a7e80c90-b140-4ea1-aee3-f4625365c9a4
+  (testing "Full garden -> For Fred"
+    (is (= [:grass :clover :violets :clover]
+           (:fred (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-9d94b273-2933-471b-86e8-dba68694c615
+  (testing "Full garden -> For Ginny"
+    (is (= [:clover :grass :grass :clover]
+           (:ginny (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-f55bc6c2-ade8-4844-87c4-87196f1b7258
+  (testing "Full garden -> For Harriet"
+    (is (= [:violets :radishes :radishes :violets]
+           (:harriet (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-759070a3-1bb1-4dd4-be2c-7cce1d7679ae
+  (testing "Full garden -> For Ileana"
+    (is (= [:grass :clover :violets :clover]
+           (:ileana (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-78578123-2755-4d4a-9c7d-e985b8dda1c6
+  (testing "Full garden -> For Joseph"
+    (is (= [:violets :clover :violets :grass]
+           (:joseph (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-6bb66df7-f433-41ab-aec2-3ead6e99f65b
+  (testing "Full garden -> For Kincaid second to last student's garden"
+    (is (= [:grass :clover :clover :grass]
+           (:kincaid (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
+
+(deftest test-d7edec11-6488-418a-94e6-ed509e0fa7eb
+  (testing "Full garden -> For Larry last student's garden"
+    (is (= [:grass :violets :clover :violets]
+           (:larry (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))


### PR DESCRIPTION
Sync and complete rewrite of all tests.

Coming up with appropriate names for each `deftest` is nearly impossible for this exercise since the test descriptions are overly long, and some tests are nested three levels deep. So, I just used the `test-<uuid>` naming convention proposed in [issue #673](https://github.com/exercism/clojure/issues/673).

I also used one `deftest` per test, as suggested in the aforementioned issue.

**Note:** There are multiple issues with the error messages when >1 tests are placed under a single `deftest`. I'll open an issue about that soon in the test runner repo.