### PR TITLE
complex-numbers: Clarify that the exponent function isn't required

### DIFF
--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,0 +1,4 @@
+# Instructions append
+
+**Note:** The instructions ask for the exponent function because they are synced with a shared repository to maintain consistency across all language tracks.
+However, for this exercise in the Clojure track, you don't need to implement it.


### PR DESCRIPTION
Adding an instructions.append to clarify that the exponent function isn't required.

Original thread:

https://forum.exercism.org/t/remove-mention-of-exponentiation-from-instructions/13225