### PR TITLE
Deprecate exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -734,13 +734,12 @@
         "name": "Binary",
         "uuid": "daf3daed-61ef-4964-8d33-e7a739c7a470",
         "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
+        "prerequisites": [],
         "difficulty": 3,
         "topics": [
           "math"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "binary-search",
@@ -846,13 +845,12 @@
         "name": "Hexadecimal",
         "uuid": "a4b1b39a-d942-4921-9b67-2bd913ff52a0",
         "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
+        "prerequisites": [],
         "difficulty": 3,
         "topics": [
           "math"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "isbn-verifier",
@@ -1009,14 +1007,12 @@
         "name": "Trinary",
         "uuid": "f8a7f5eb-e317-4ffa-bdef-6e30a36511eb",
         "practices": [],
-        "prerequisites": [
-          "numbers",
-          "strings"
-        ],
+        "prerequisites": [],
         "difficulty": 3,
         "topics": [
           "math"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "allergies",
@@ -1111,16 +1107,13 @@
         "slug": "octal",
         "name": "Octal",
         "uuid": "fa596153-0cbe-40e9-a4d6-1a66fe6ef7e5",
-        "practices": [
-          "numbers"
-        ],
-        "prerequisites": [
-          "numbers"
-        ],
+        "practices": [],
+        "prerequisites": [],
         "difficulty": 4,
         "topics": [
           "math"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "spiral-matrix",
@@ -1365,10 +1358,10 @@
         "practices": [],
         "prerequisites": [
           "lists",
-          "closures"
+          "closures",
+          "vectors"
         ],
-        "difficulty": 5,
-        "status": "wip"
+        "difficulty": 5
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -243,13 +243,12 @@
         "name": "Accumulate",
         "uuid": "49f62bbc-0f60-4922-b5a6-f266b80442f4",
         "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
+        "prerequisites": [],
         "difficulty": 2,
         "topics": [
           "algorithms, core_functions"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "acronym",


### PR DESCRIPTION
Since **'All your base'** has been implemented, the following exercises are marked as deprecated:
1. Binary
2. Trinary
3. Octal
4. Hexadecimal

I've also deprecated **'accumulate'** since **'list-ops'** will be published soon. Therefore, I'm marking the current PR as draft. It will be merged after https://github.com/exercism/clojure/pull/685