### PR TITLE
bird-watcher: Update exemplar solution

### DIFF
--- a/exercises/concept/bird-watcher/.docs/hints.md
+++ b/exercises/concept/bird-watcher/.docs/hints.md
@@ -6,7 +6,7 @@
 
 ## 2. Check how many birds visited today
 
-- The [`last`][last] function can be used to return the last item in a sequential collection.
+- The [`peek`][peek] function can be used to return the last item in a vector.
 
 ## 3. Increment today's count
 
@@ -44,7 +44,7 @@
 [every?]: https://clojuredocs.org/clojure.core/every_q
 [filter]: https://clojuredocs.org/clojure.core/filter
 [inc]: https://clojuredocs.org/clojure.core/inc
-[last]: https://clojuredocs.org/clojure.core/last
+[peek]: https://clojuredocs.org/clojure.core/peek
 [not]: https://clojuredocs.org/clojure.core/not
 [pos?]: https://clojuredocs.org/clojure.core/pos_q
 [reduce]: https://clojuredocs.org/clojure.core/reduce

--- a/exercises/concept/bird-watcher/.meta/exemplar.clj
+++ b/exercises/concept/bird-watcher/.meta/exemplar.clj
@@ -3,13 +3,13 @@
 (def last-week [0 2 5 3 7 8 4])
 
 (defn today [birds]
-  (last birds))
+  (peek birds))
 
 (defn inc-bird [birds]
   (update birds (dec (count birds)) inc))
 
 (defn day-without-birds? [birds]
-  (pos? (count (filter zero? birds))))
+  (not (every? pos? birds)))
 
 (defn n-days-count [birds n]
   (reduce + (take n birds)))


### PR DESCRIPTION
The hints for task 4 mention `every?`, `pos?`, and `not`. However, the exemplar solution is `(pos? (count (filter zero? birds)))`, which is not only different, but also suboptimal. This PR updates the solution to `(not (every? pos? birds))` to align with the hints.

I’ve also replaced the `last` function with `peek` since this exercise deals exclusively with vectors, and `peek` is the recommended way to retrieve the last element of a vector.
