### PR TITLE
Update lists concept

### DIFF
--- a/concepts/lists/.meta/config.json
+++ b/concepts/lists/.meta/config.json
@@ -1,4 +1,11 @@
 {
   "blurb": "Lists are immutable, sequential collections representing function calls unless quoted.",
-  "authors": ["porkostomus", "bemself", "cstby"]
+  "authors": [
+    "porkostomus",
+    "bemself",
+    "cstby"
+  ],
+  "contributors": [
+    "tasxatzial"
+  ]
 }

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -7,7 +7,7 @@
 - Clojure will try to evaluate lists, treating the first item as a function.
 - Core functions:
   - [`first`][first] returns the first item in the list.
-  - [`rest`][rest] returns a sequence of all items of the list except the first.
+  - [`rest`][rest] returns a list of all items of the list except the first.
   - [`count`][count] returns the number of items in the list.
   - [`conj`][conj] adds one or more items to the beginning of the list.
 

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -3,16 +3,16 @@
 ## Key Learnings
 
 - Lists are collections.
-- Lists can be created using `list` or by using a single quote.
+- Lists can be created using [`list`][list] or by using a single quote.
 - Clojure will try to evaluate lists, treating the first item as a function.
 - Core functions:
-  - `first` returns the first item in the list.
-  - `rest` returns the list without its first item.
-  - `count` returns the number of items in the list.
-  - `conj` adds one or more items to the beginning of the list.
+  - [`first`][first] returns the first item in the list.
+  - [`rest`][rest] returns the list without its first item.
+  - [`count`][count] returns the number of items in the list.
+  - [`conj`][conj] adds one or more items to the beginning of the list.
 
-## Additional Resources
-
-- [list - clojure.core | ClojureDocs](https://clojuredocs.org/clojure.core/list)
-- [Data Structures](https://clojure.org/reference/data_structures)
-- [Lists in Clojurescript](https://cljs.github.io/api/syntax/list)
+[list]: https://clojuredocs.org/clojure.core/list
+[first]: https://clojuredocs.org/clojure.core/first
+[rest]: https://clojuredocs.org/clojure.core/rest
+[count]: https://clojuredocs.org/clojure.core/count
+[conj]: https://clojuredocs.org/clojure.core/conj

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -7,7 +7,7 @@
 - Clojure will try to evaluate lists, treating the first item as a function.
 - Core functions:
   - [`first`][first] returns the first item in the list.
-  - [`rest`][rest] returns the list without its first item.
+  - [`rest`][rest] returns a sequence of all items of the list except the first.
   - [`count`][count] returns the number of items in the list.
   - [`conj`][conj] adds one or more items to the beginning of the list.
 

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -6,11 +6,10 @@
 - Lists can be created using `list` or by using a single quote.
 - Clojure will try to evaluate lists, treating the first item as a function.
 - Core functions:
-  - `cons` returns a list with the new item added to beginning.
-  - `first` returns the first item from a list.
-  - `rest` returns the list without the first item.
+  - `first` returns the first item in the list.
+  - `rest` returns the list without its first item.
   - `count` returns the number of items in the list.
-  - `conj` returns a list with items appended in it.
+  - `conj` adds one or more items to the beginning of the list.
 
 ## Additional Resources
 

--- a/concepts/lists/links.json
+++ b/concepts/lists/links.json
@@ -1,14 +1,10 @@
 [
   {
-    "url": "https://clojuredocs.org/clojure.core/list",
-    "description": "list - clojure.core | ClojureDocs"
+    "url": "https://clojure.org/reference/sequences",
+    "description": "Sequences"
   },
   {
     "url": "https://clojure.org/reference/data_structures",
     "description": "Data Structures"
-  },
-  {
-    "url": "https://cljs.github.io/api/syntax/list",
-    "description": "Lists in Clojurescript"
   }
 ]

--- a/concepts/lists/links.json
+++ b/concepts/lists/links.json
@@ -1,9 +1,5 @@
 [
   {
-    "url": "https://clojure.org/reference/sequences",
-    "description": "Sequences"
-  },
-  {
     "url": "https://clojure.org/reference/data_structures",
     "description": "Data Structures"
   }


### PR DESCRIPTION
Quick update for the lists concept

* `cons` isn't used to add elements to the beginning of a list. This is a job for `conj`. Therefore, `cons` has been completely removed.
* `conj` does not append items to a list; it prepends them (adds to the beginning). This has been clarified.
* Added links to all functions
* Updated links.json