### PR TITLE
bird-watcher: Fix introduction example

### DIFF
--- a/exercises/concept/bird-watcher/.docs/introduction.md
+++ b/exercises/concept/bird-watcher/.docs/introduction.md
@@ -6,7 +6,7 @@ A `vector` in Clojure is a sequential, indexed, immutable collection of zero or 
 (def empty [])
 (def single-value [5])
 (def single-value-alternative (vector 5))
-(def three-values [a b c])
+(def three-values [\a \b \c])
 ```
 
 Elements can be retrieved from a vector using an index. Clojure vectors are zero-based, meaning that the first element's index is always zero:

--- a/exercises/concept/bird-watcher/.docs/introduction.md
+++ b/exercises/concept/bird-watcher/.docs/introduction.md
@@ -6,7 +6,7 @@ A `vector` in Clojure is a sequential, indexed, immutable collection of zero or 
 (def empty [])
 (def single-value [5])
 (def single-value-alternative (vector 5))
-(def three-values [\a \b \c])
+(def three-values [1 "a" "b"])
 ```
 
 Elements can be retrieved from a vector using an index. Clojure vectors are zero-based, meaning that the first element's index is always zero:


### PR DESCRIPTION
Small fix in an example that can't be evaluated.

I am not sure if could be better move the example to:
```clojure
(def three-values [4 5 6])
```
as the exercise is presented in part of the Numbers path... What do you thing?