### PR TITLE
gigasecond: Sync tests

### DIFF
--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
@@ -13,6 +20,11 @@ description = "third test for date only specification of time"
 
 [c9d89a7d-06f8-4e28-a305-64f1b2abc693]
 description = "full time specified"
+include = false
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
+include = false
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"

--- a/exercises/practice/gigasecond/src/gigasecond.clj
+++ b/exercises/practice/gigasecond/src/gigasecond.clj
@@ -1,5 +1,7 @@
 (ns gigasecond)
 
-(defn from []  ;; <- arglist goes here
-    ;; your code goes here
-)
+(defn from
+  "Determines the date one gigasecond after the given date"
+  [date]
+  ;; function body
+  )

--- a/exercises/practice/gigasecond/test/gigasecond_test.clj
+++ b/exercises/practice/gigasecond/test/gigasecond_test.clj
@@ -2,20 +2,20 @@
   (:require [clojure.test :refer [deftest testing is]]
             gigasecond))
 
-(deftest test-92fbe71c-ea52-4fac-bd77-be38023cacf7
-  (testing "Date-only specification of time"
+(deftest from_test_1
+  (testing "date-only specification of time"
     (is (= [2043 1 1] (gigasecond/from 2011 4 25)))))
 
-(deftest test-6d86dd16-6f7a-47be-9e58-bb9fb2ae1433
-  (testing "Second test for date-only specification of time"
+(deftest from_test_2
+  (testing "second test for date-only specification of time"
     (is (= [2009 2 19] (gigasecond/from 1977 6 13)))))
 
-(deftest test-77eb8502-2bca-4d92-89d9-7b39ace28dd5
-  (testing "Third test for date-only specification of time"
+(deftest from_test_3
+  (testing "third test for date-only specification of time"
     (is (= [1991 3 27] (gigasecond/from 1959 7 19)))))
 
-(deftest test-fcec307c-7529-49ab-b0fe-20309197618a
-  (testing "Does not mutate the input"
+(deftest from_test_4
+  (testing "does not mutate the input"
     (let [date [1959 7 19]
           new-date (apply gigasecond/from date)]
       (is (= [1959 7 19] date)))))

--- a/exercises/practice/gigasecond/test/gigasecond_test.clj
+++ b/exercises/practice/gigasecond/test/gigasecond_test.clj
@@ -1,16 +1,21 @@
 (ns gigasecond-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest testing is]]
             gigasecond))
 
-(deftest from-apr-25-2011
-  (is (= [2043 1 1] (gigasecond/from 2011 4 25))))
+(deftest test-92fbe71c-ea52-4fac-bd77-be38023cacf7
+  (testing "Date-only specification of time"
+    (is (= [2043 1 1] (gigasecond/from 2011 4 25)))))
 
-(deftest from-jun-13-1977
-  (is (= [2009 2 19] (gigasecond/from 1977 6 13))))
+(deftest test-6d86dd16-6f7a-47be-9e58-bb9fb2ae1433
+  (testing "Second test for date-only specification of time"
+    (is (= [2009 2 19] (gigasecond/from 1977 6 13)))))
 
-(deftest from-jul-19-1959
-  (is (= [1991 3 27] (gigasecond/from 1959 7 19))))
+(deftest test-77eb8502-2bca-4d92-89d9-7b39ace28dd5
+  (testing "Third test for date-only specification of time"
+    (is (= [1991 3 27] (gigasecond/from 1959 7 19)))))
 
-;; customize this to test your birthday and find your gigasecond date:
-;; (deftest your-birthday
-;;   (is (= [year2 month2 day2] (gigasecond/from year1 month1 day1))))
+(deftest test-fcec307c-7529-49ab-b0fe-20309197618a
+  (testing "Does not mutate the input"
+    (let [date [1959 7 19]
+          new-date (apply gigasecond/from date)]
+      (is (= [1959 7 19] date)))))


### PR DESCRIPTION
Also

* Updated the gigasecond.clj starter file with a proper function template
* Specs mention that some tests check only for date (not time), which appears to be the case in the existing implementation. Therefore, the tests that also check time were marked as excluded.
* Removed the commented out test since it's not part of the specs.