### PR TITLE
matching-brackets: Explicitly check with true? in tests

### DIFF
--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -6,7 +6,8 @@
     "AndreaCrotti",
     "haus",
     "sjwarner-bp",
-    "yurrriq"
+    "yurrriq",
+    "tasxatzial"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/matching-brackets/src/matching_brackets.clj
+++ b/exercises/practice/matching-brackets/src/matching_brackets.clj
@@ -1,5 +1,6 @@
 (ns matching-brackets)
 
-(defn valid? [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn valid?
+  [s]
+  ;; function body
+  )

--- a/exercises/practice/matching-brackets/test/matching_brackets_test.clj
+++ b/exercises/practice/matching-brackets/test/matching_brackets_test.clj
@@ -2,82 +2,82 @@
   (:require [clojure.test :refer [deftest testing is]]
             matching-brackets))
 
-(deftest paired-square-brackets
-  (testing "paired square brackets"
-    (is (matching-brackets/valid? "[]"))))
+(deftest test-81ec11da-38dd-442a-bcf9-3de7754609a5
+  (testing "Paired square brackets"
+    (is (true? (matching-brackets/valid? "[]")))))
 
-(deftest empty-string
+(deftest test-287f0167-ac60-4b64-8452-a0aa8f4e5238
   (testing "Empty string"
-    (is (matching-brackets/valid? ""))))
+    (is (true? (matching-brackets/valid? "")))))
 
-(deftest unpaired-brackets
+(deftest test-6c3615a3-df01-4130-a731-8ef5f5d78dac
   (testing "Unpaired brackets"
     (is (false? (matching-brackets/valid? "[[")))))
 
-(deftest wrong-ordered-brackets
+(deftest test-9d414171-9b98-4cac-a4e5-941039a97a77
   (testing "Wrong ordered brackets"
     (is (false? (matching-brackets/valid? "}{")))))
 
-(deftest wrong-closing-bracket
+(deftest test-f0f97c94-a149-4736-bc61-f2c5148ffb85
   (testing "Wrong closing bracket"
     (is (false? (matching-brackets/valid? "{]")))))
 
-(deftest paired-with-whitespace
+(deftest test-754468e0-4696-4582-a30e-534d47d69756
   (testing "Paired with whitespace"
-    (is (matching-brackets/valid? "{ }"))))
+    (is (true? (matching-brackets/valid? "{ }")))))
 
-(deftest partially-paired-brackets
+(deftest test-ba84f6ee-8164-434a-9c3e-b02c7f8e8545
   (testing "Partially paired brackets"
     (is (false? (matching-brackets/valid? "{[])")))))
 
-(deftest simple-nested-brackets
+(deftest test-3c86c897-5ff3-4a2b-ad9b-47ac3a30651d
   (testing "Simple nested brackets"
-    (is (matching-brackets/valid? "{[]}"))))
+    (is (true? (matching-brackets/valid? "{[]}")))))
 
-(deftest several-paired-brackets
+(deftest test-2d137f2c-a19e-4993-9830-83967a2d4726
   (testing "Several paired brackets"
-    (is (matching-brackets/valid? "{}[]"))))
+    (is (true? (matching-brackets/valid? "{}[]")))))
 
-(deftest paired-and-nested-brackets
+(deftest test-2e1f7b56-c137-4c92-9781-958638885a44
   (testing "Paired and nested brackets"
-    (is (matching-brackets/valid? "([{}({}[])])"))))
+    (is (true? (matching-brackets/valid? "([{}({}[])])")))))
 
-(deftest unopened-closing-brackets
+(deftest test-84f6233b-e0f7-4077-8966-8085d295c19b
   (testing "Unopened closing brackets"
     (is (false? (matching-brackets/valid? "{[)][]}")))))
  
-(deftest unpaired-and-nested-brackets
+(deftest test-9b18c67d-7595-4982-b2c5-4cb949745d49
   (testing "Unpaired and nested brackets"
     (is (false? (matching-brackets/valid? "([{])")))))
 
-(deftest paired-and-wrong-nested-brackets
+(deftest test-a0205e34-c2ac-49e6-a88a-899508d7d68e
   (testing "Paired and wrong nested brackets"
     (is (false? (matching-brackets/valid? "[({]})")))))
 
-(deftest paired-and-wrong-nested-brackets-but-innermost-are-correct
+(deftest test-1d5c093f-fc84-41fb-8c2a-e052f9581602
   (testing "Paired and wrong nested brackets but innermost are correct"
     (is (false? (matching-brackets/valid? "[({}])")))))
 
-(deftest paired-and-incomplete-brackets
+(deftest test-ef47c21b-bcfd-4998-844c-7ad5daad90a8
   (testing "Paired and incomplete brackets"
     (is (false? (matching-brackets/valid? "{}[")))))
 
-(deftest too-many-closing-brackets
+(deftest test-a4675a40-a8be-4fc2-bc47-2a282ce6edbe
   (testing "Too many closing brackets"
     (is (false? (matching-brackets/valid? "[]]")))))
 
-(deftest early-unexpected-brackets
+(deftest test-a345a753-d889-4b7e-99ae-34ac85910d1a
   (testing "Early unexpected brackets"
     (is (false? (matching-brackets/valid? ")()")))))
 
-(deftest early-mismatched-brackets
+(deftest test-21f81d61-1608-465a-b850-baa44c5def83
   (testing "Early mismatched brackets"
     (is (false? (matching-brackets/valid? "{)()")))))
 
-(deftest math-expression
+(deftest test-99255f93-261b-4435-a352-02bdecc9bdf2
   (testing "Math expression"
-    (is (matching-brackets/valid? "(((185 + 223.85) * 15) - 543)/2"))))
+    (is (true? (matching-brackets/valid? "(((185 + 223.85) * 15) - 543)/2")))))
 
-(deftest complex-latex-expression
+(deftest test-8e357d79-f302-469a-8515-2561877256a1
   (testing "Complex latex expression"
-    (is (matching-brackets/valid? "\\\\left(\\\\begin{array}{cc} \\\\frac{1}{3} & x\\\\\\\\ \\\\mathrm{e}^{x} &... x^2 \\\\end{array}\\\\right)"))))
+    (is (true? (matching-brackets/valid? "\\\\left(\\\\begin{array}{cc} \\\\frac{1}{3} & x\\\\\\\\ \\\\mathrm{e}^{x} &... x^2 \\\\end{array}\\\\right)")))))

--- a/exercises/practice/matching-brackets/test/matching_brackets_test.clj
+++ b/exercises/practice/matching-brackets/test/matching_brackets_test.clj
@@ -2,82 +2,82 @@
   (:require [clojure.test :refer [deftest testing is]]
             matching-brackets))
 
-(deftest test-81ec11da-38dd-442a-bcf9-3de7754609a5
-  (testing "Paired square brackets"
+(deftest valid?_test_1
+  (testing "paired square brackets"
     (is (true? (matching-brackets/valid? "[]")))))
 
-(deftest test-287f0167-ac60-4b64-8452-a0aa8f4e5238
-  (testing "Empty string"
+(deftest valid?_test_2
+  (testing "empty string"
     (is (true? (matching-brackets/valid? "")))))
 
-(deftest test-6c3615a3-df01-4130-a731-8ef5f5d78dac
-  (testing "Unpaired brackets"
+(deftest valid?_test_3
+  (testing "unpaired brackets"
     (is (false? (matching-brackets/valid? "[[")))))
 
-(deftest test-9d414171-9b98-4cac-a4e5-941039a97a77
-  (testing "Wrong ordered brackets"
+(deftest valid?_test_4
+  (testing "wrong ordered brackets"
     (is (false? (matching-brackets/valid? "}{")))))
 
-(deftest test-f0f97c94-a149-4736-bc61-f2c5148ffb85
-  (testing "Wrong closing bracket"
+(deftest valid?_test_5
+  (testing "wrong closing bracket"
     (is (false? (matching-brackets/valid? "{]")))))
 
-(deftest test-754468e0-4696-4582-a30e-534d47d69756
-  (testing "Paired with whitespace"
+(deftest valid?_test_6
+  (testing "paired with whitespace"
     (is (true? (matching-brackets/valid? "{ }")))))
 
-(deftest test-ba84f6ee-8164-434a-9c3e-b02c7f8e8545
-  (testing "Partially paired brackets"
+(deftest valid?_test_7
+  (testing "partially paired brackets"
     (is (false? (matching-brackets/valid? "{[])")))))
 
-(deftest test-3c86c897-5ff3-4a2b-ad9b-47ac3a30651d
-  (testing "Simple nested brackets"
+(deftest valid?_test_8
+  (testing "simple nested brackets"
     (is (true? (matching-brackets/valid? "{[]}")))))
 
-(deftest test-2d137f2c-a19e-4993-9830-83967a2d4726
-  (testing "Several paired brackets"
+(deftest valid?_test_9
+  (testing "several paired brackets"
     (is (true? (matching-brackets/valid? "{}[]")))))
 
-(deftest test-2e1f7b56-c137-4c92-9781-958638885a44
-  (testing "Paired and nested brackets"
+(deftest valid?_test_10
+  (testing "paired and nested brackets"
     (is (true? (matching-brackets/valid? "([{}({}[])])")))))
 
-(deftest test-84f6233b-e0f7-4077-8966-8085d295c19b
-  (testing "Unopened closing brackets"
+(deftest valid?_test_11
+  (testing "unopened closing brackets"
     (is (false? (matching-brackets/valid? "{[)][]}")))))
  
-(deftest test-9b18c67d-7595-4982-b2c5-4cb949745d49
-  (testing "Unpaired and nested brackets"
+(deftest valid?_test_12
+  (testing "unpaired and nested brackets"
     (is (false? (matching-brackets/valid? "([{])")))))
 
-(deftest test-a0205e34-c2ac-49e6-a88a-899508d7d68e
-  (testing "Paired and wrong nested brackets"
+(deftest valid?_test_13
+  (testing "paired and wrong nested brackets"
     (is (false? (matching-brackets/valid? "[({]})")))))
 
-(deftest test-1d5c093f-fc84-41fb-8c2a-e052f9581602
-  (testing "Paired and wrong nested brackets but innermost are correct"
+(deftest valid?_test_14
+  (testing "paired and wrong nested brackets but innermost are correct"
     (is (false? (matching-brackets/valid? "[({}])")))))
 
-(deftest test-ef47c21b-bcfd-4998-844c-7ad5daad90a8
-  (testing "Paired and incomplete brackets"
+(deftest valid?_test_15
+  (testing "paired and incomplete brackets"
     (is (false? (matching-brackets/valid? "{}[")))))
 
-(deftest test-a4675a40-a8be-4fc2-bc47-2a282ce6edbe
-  (testing "Too many closing brackets"
+(deftest valid?_test_16
+  (testing "too many closing brackets"
     (is (false? (matching-brackets/valid? "[]]")))))
 
-(deftest test-a345a753-d889-4b7e-99ae-34ac85910d1a
-  (testing "Early unexpected brackets"
+(deftest valid?_test_17
+  (testing "early unexpected brackets"
     (is (false? (matching-brackets/valid? ")()")))))
 
-(deftest test-21f81d61-1608-465a-b850-baa44c5def83
-  (testing "Early mismatched brackets"
+(deftest valid?_test_18
+  (testing "early mismatched brackets"
     (is (false? (matching-brackets/valid? "{)()")))))
 
-(deftest test-99255f93-261b-4435-a352-02bdecc9bdf2
-  (testing "Math expression"
+(deftest valid?_test_19
+  (testing "math expression"
     (is (true? (matching-brackets/valid? "(((185 + 223.85) * 15) - 543)/2")))))
 
-(deftest test-8e357d79-f302-469a-8515-2561877256a1
-  (testing "Complex latex expression"
+(deftest valid?_test_20
+  (testing "complex latex expression"
     (is (true? (matching-brackets/valid? "\\\\left(\\\\begin{array}{cc} \\\\frac{1}{3} & x\\\\\\\\ \\\\mathrm{e}^{x} &... x^2 \\\\end{array}\\\\right)")))))


### PR DESCRIPTION
Made the tests consistent by explicitly checking with `true?` as well, as `true` is the other value expected to be returned by `valid?`