### PR TITLE
pangram: Sync tests

### DIFF
--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -7,7 +7,8 @@
     "haus",
     "sjwarner-bp",
     "tstirrat15",
-    "yurrriq"
+    "yurrriq",
+    "tasxatzial"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
@@ -31,3 +38,8 @@ description = "mixed case and punctuation"
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
+include = false
+
+[7138e389-83e4-4c6e-8413-1e40a0076951]
+description = "a-m and A-M are 26 different characters but not a pangram"
+reimplements = "2577bf54-83c8-402d-a64b-a2c0f7bb213a"

--- a/exercises/practice/pangram/src/pangram.clj
+++ b/exercises/practice/pangram/src/pangram.clj
@@ -1,5 +1,7 @@
 (ns pangram)
 
-(defn pangram? [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn pangram?
+  "Returns true if the given string is a pangram; otherwise, returns false"
+  [s]
+  ;; function body
+  )

--- a/exercises/practice/pangram/test/pangram_test.clj
+++ b/exercises/practice/pangram/test/pangram_test.clj
@@ -2,42 +2,42 @@
   (:require [clojure.test :refer [deftest testing is]]
             pangram))
 
-(deftest test-64f61791-508e-4f5c-83ab-05de042b0149
-  (testing "Empty sentence"
+(deftest pangram?_test_1
+  (testing "empty sentence"
     (is (false? (pangram/pangram? "")))))
 
-(deftest test-74858f80-4a4d-478b-8a5e-c6477e4e4e84
-  (testing "Perfect lower case"
+(deftest pangram?_test_2
+  (testing "perfect lower case"
     (is (true? (pangram/pangram? "abcdefghijklmnopqrstuvwxyz")))))
 
-(deftest test-61288860-35ca-4abe-ba08-f5df76ecbdcd
-  (testing "Only lower case"
+(deftest pangram?_test_3
+  (testing "only lower case"
     (is (true? (pangram/pangram? "the quick brown fox jumps over the lazy dog")))))
 
-(deftest test-6564267d-8ac5-4d29-baf2-e7d2e304a743
-  (testing "Missing the letter 'x'"
+(deftest pangram?_test_4
+  (testing "missing the letter 'x'"
     (is (false? (pangram/pangram? "a quick movement of the enemy will jeopardize five gunboats")))))
 
-(deftest test-c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0
-  (testing "Missing the letter 'h'"
+(deftest pangram?_test_5
+  (testing "missing the letter 'h'"
     (is (false? (pangram/pangram? "five boxing wizards jump quickly at it")))))
 
-(deftest test-d835ec38-bc8f-48e4-9e36-eb232427b1df
-  (testing "With underscores"
+(deftest pangram?_test_6
+  (testing "with underscores"
     (is (true? (pangram/pangram? "the_quick_brown_fox_jumps_over_the_lazy_dog")))))
 
-(deftest test-8cc1e080-a178-4494-b4b3-06982c9be2a8
-  (testing "With numbers"
+(deftest pangram?_test_7
+  (testing "with numbers"
     (is (true? (pangram/pangram? "the 1 quick brown fox jumps over the 2 lazy dogs")))))
 
-(deftest test-bed96b1c-ff95-45b8-9731-fdbdcb6ede9a
-  (testing "Missing letters replaced by numbers"
+(deftest pangram?_test_8
+  (testing "missing letters replaced by numbers"
     (is (false? (pangram/pangram? "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")))))
 
-(deftest test-938bd5d8-ade5-40e2-a2d9-55a338a01030
-  (testing "Mixed case and punctuation"
+(deftest pangram?_test_9
+  (testing "mixed case and punctuation"
     (is (true? (pangram/pangram? "\"Five quacking Zephyrs jolt my wax bed.\"")))))
 
-(deftest test-7138e389-83e4-4c6e-8413-1e40a0076951
+(deftest pangram?_test_10
   (testing "a-m and A-M are 26 different characters but not a pangram"
     (is (false? (pangram/pangram? "abcdefghijklm ABCDEFGHIJKLM")))))

--- a/exercises/practice/pangram/test/pangram_test.clj
+++ b/exercises/practice/pangram/test/pangram_test.clj
@@ -1,38 +1,43 @@
 (ns pangram-test
-  (:require [clojure.test :refer [is deftest]]
-            [pangram :refer [pangram?]]))
+  (:require [clojure.test :refer [deftest testing is]]
+            pangram))
 
-(deftest empty-sentence
-  (is (false? (pangram? ""))))
+(deftest test-64f61791-508e-4f5c-83ab-05de042b0149
+  (testing "Empty sentence"
+    (is (false? (pangram/pangram? "")))))
 
-(deftest lowercase-pangram
-  (is (pangram? "the quick brown fox jumps over the lazy dog")))
+(deftest test-74858f80-4a4d-478b-8a5e-c6477e4e4e84
+  (testing "Perfect lower case"
+    (is (true? (pangram/pangram? "abcdefghijklmnopqrstuvwxyz")))))
 
-(deftest missing-character-x
-  (is
-   (false?
-    (pangram? "a quick movement of the enemy will jeopardize five gunboats"))))
+(deftest test-61288860-35ca-4abe-ba08-f5df76ecbdcd
+  (testing "Only lower case"
+    (is (true? (pangram/pangram? "the quick brown fox jumps over the lazy dog")))))
 
-(deftest another-missing-character-x
-  (is
-   (false?
-    (pangram? "the quick brown fish jumps over the lazy dog"))))
+(deftest test-6564267d-8ac5-4d29-baf2-e7d2e304a743
+  (testing "Missing the letter 'x'"
+    (is (false? (pangram/pangram? "a quick movement of the enemy will jeopardize five gunboats")))))
 
-(deftest with-underscores
-  (is (pangram? "the_quick_brown_fox_jumps_over_the_lazy_dog")))
+(deftest test-c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0
+  (testing "Missing the letter 'h'"
+    (is (false? (pangram/pangram? "five boxing wizards jump quickly at it")))))
 
-(deftest with-numbers
-  (is (pangram? "the 1 quick brown fox jumps over the 2 lazy dogs")))
+(deftest test-d835ec38-bc8f-48e4-9e36-eb232427b1df
+  (testing "With underscores"
+    (is (true? (pangram/pangram? "the_quick_brown_fox_jumps_over_the_lazy_dog")))))
 
-(deftest missing-letters-replaced-by-numbers
-  (is
-   (false?
-    (pangram? "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"))))
+(deftest test-8cc1e080-a178-4494-b4b3-06982c9be2a8
+  (testing "With numbers"
+    (is (true? (pangram/pangram? "the 1 quick brown fox jumps over the 2 lazy dogs")))))
 
-(deftest mixed-case-and-punctuation
-  (is (pangram? "\"Five quacking Zephyrs jolt my wax bed.\"")))
+(deftest test-bed96b1c-ff95-45b8-9731-fdbdcb6ede9a
+  (testing "Missing letters replaced by numbers"
+    (is (false? (pangram/pangram? "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")))))
 
-(deftest upper-and-lower-not-counted-separately
-  (is
-   (false?
-    (pangram? "the quick brown fox jumps over with lazy FX"))))
+(deftest test-938bd5d8-ade5-40e2-a2d9-55a338a01030
+  (testing "Mixed case and punctuation"
+    (is (true? (pangram/pangram? "\"Five quacking Zephyrs jolt my wax bed.\"")))))
+
+(deftest test-7138e389-83e4-4c6e-8413-1e40a0076951
+  (testing "a-m and A-M are 26 different characters but not a pangram"
+    (is (false? (pangram/pangram? "abcdefghijklm ABCDEFGHIJKLM")))))


### PR DESCRIPTION
Also

* Updated the pangram.clj starter file with a proper function template
* Explicitly test with `true?` as well, as `true` is the other value expected to be returned by `pangram?`