### PR TITLE
armstrong-numbers: Include excluded tests

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -7,7 +7,8 @@
     "imtayadeway",
     "mawis",
     "mtkp",
-    "sjwarner-bp"
+    "sjwarner-bp",
+    "tasxatzial"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/armstrong-numbers/.meta/src/example.clj
+++ b/exercises/practice/armstrong-numbers/.meta/src/example.clj
@@ -1,7 +1,7 @@
 (ns armstrong-numbers)
 
 (defn expt [base pow]
-  (reduce * 1 (repeat pow base)))
+  (reduce *' 1 (repeat pow base)))
 
 (defn armstrong? [n]
   (let [digits (map (comp read-string str) (str n))

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -38,8 +38,6 @@ description = "Seven-digit number that is not an Armstrong number"
 
 [5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
 description = "Armstrong number containing seven zeroes"
-include = false
 
 [12ffbf10-307a-434e-b4ad-c925680e1dd4]
 description = "The largest and last Armstrong number"
-include = false

--- a/exercises/practice/armstrong-numbers/src/armstrong_numbers.clj
+++ b/exercises/practice/armstrong-numbers/src/armstrong_numbers.clj
@@ -1,5 +1,7 @@
 (ns armstrong-numbers)
 
-(defn armstrong? [num] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn armstrong?
+  "Returns true if the given number is an Armstrong number; otherwise, returns false"
+  [num]
+  ;; function body
+  )

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -4,36 +4,36 @@
 
 (deftest armstrong-number-0
   (testing "Zero is an Armstrong number"
-    (is (armstrong-numbers/armstrong? 0))))
+    (is (true? (armstrong-numbers/armstrong? 0)))))
 
 (deftest armstrong-number-5
   (testing "Single-digit numbers are Armstrong numbers"
-    (is (armstrong-numbers/armstrong? 5))))
+    (is (true? (armstrong-numbers/armstrong? 5)))))
 
 (deftest not-armstrong-number-10
   (testing "There are no two-digit Armstrong numbers"
-    (is (not (armstrong-numbers/armstrong? 10)))))
+    (is (false? (armstrong-numbers/armstrong? 10)))))
 
 (deftest armstrong-number-153
   (testing "Three-digit number that is an Armstrong number"
-    (is (armstrong-numbers/armstrong? 153))))
+    (is (true? (armstrong-numbers/armstrong? 153)))))
 
 (deftest not-armstrong-number-100
   (testing "Three-digit number that is not an Armstrong number"
-    (is (not (armstrong-numbers/armstrong? 100)))))
+    (is (false? (armstrong-numbers/armstrong? 100)))))
 
 (deftest armstrong-number-9474
   (testing "Four-digit number that is an Armstrong number"
-    (is (armstrong-numbers/armstrong? 9474))))
+    (is (true? (armstrong-numbers/armstrong? 9474)))))
 
 (deftest not-armstrong-number-9475
   (testing "Four-digit number that is not an Armstrong number"
-    (is (not (armstrong-numbers/armstrong? 9475)))))
+    (is (false? (armstrong-numbers/armstrong? 9475)))))
 
 (deftest armstrong-number-9926315
   (testing "Seven-digit number that is an Armstrong number"
-    (is (armstrong-numbers/armstrong? 9926315))))
+    (is (true? (armstrong-numbers/armstrong? 9926315)))))
 
 (deftest not-armstrong-number-9926314
   (testing "Seven-digit number that is not an Armstrong number"
-    (is (not (armstrong-numbers/armstrong? 9926314)))))
+    (is (false? (armstrong-numbers/armstrong? 9926314)))))

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -37,3 +37,11 @@
 (deftest not-armstrong-number-9926314
   (testing "Seven-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 9926314)))))
+
+(deftest armstrong-number-186709961001538790100634132976990
+  (testing "Armstrong number containing seven zeroes"
+    (is (true? (armstrong-numbers/armstrong? 186709961001538790100634132976990)))))
+
+(deftest armstrong-number-115132219018763992565095597973971522401
+  (testing "The largest and last Armstrong number"
+    (is (true? (armstrong-numbers/armstrong? 115132219018763992565095597973971522401)))))

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -1,39 +1,39 @@
 (ns armstrong-numbers-test
   (:require [clojure.test :refer [deftest is testing]]
-            [armstrong-numbers :refer [armstrong?]]))
+            armstrong-numbers))
 
 (deftest armstrong-number-0
   (testing "Zero is an Armstrong number"
-    (is (armstrong? 0))))
+    (is (armstrong-numbers/armstrong? 0))))
 
 (deftest armstrong-number-5
   (testing "Single-digit numbers are Armstrong numbers"
-    (is (armstrong? 5))))
+    (is (armstrong-numbers/armstrong? 5))))
 
 (deftest not-armstrong-number-10
   (testing "There are no two-digit Armstrong numbers"
-    (is (not (armstrong? 10)))))
+    (is (not (armstrong-numbers/armstrong? 10)))))
 
 (deftest armstrong-number-153
   (testing "Three-digit number that is an Armstrong number"
-    (is (armstrong? 153))))
+    (is (armstrong-numbers/armstrong? 153))))
 
 (deftest not-armstrong-number-100
   (testing "Three-digit number that is not an Armstrong number"
-    (is (not (armstrong? 100)))))
+    (is (not (armstrong-numbers/armstrong? 100)))))
 
 (deftest armstrong-number-9474
   (testing "Four-digit number that is an Armstrong number"
-    (is (armstrong? 9474))))
+    (is (armstrong-numbers/armstrong? 9474))))
 
 (deftest not-armstrong-number-9475
   (testing "Four-digit number that is not an Armstrong number"
-    (is (not (armstrong? 9475)))))
+    (is (not (armstrong-numbers/armstrong? 9475)))))
 
 (deftest armstrong-number-9926315
   (testing "Seven-digit number that is an Armstrong number"
-    (is (armstrong? 9926315))))
+    (is (armstrong-numbers/armstrong? 9926315))))
 
 (deftest not-armstrong-number-9926314
   (testing "Seven-digit number that is not an Armstrong number"
-    (is (not (armstrong? 9926314)))))
+    (is (not (armstrong-numbers/armstrong? 9926314)))))

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -2,46 +2,46 @@
   (:require [clojure.test :refer [deftest is testing]]
             armstrong-numbers))
 
-(deftest armstrong-number-0
+(deftest test-c1ed103c-258d-45b2-be73-d8c6d9580c7b
   (testing "Zero is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 0)))))
 
-(deftest armstrong-number-5
+(deftest test-579e8f03-9659-4b85-a1a2-d64350f6b17a
   (testing "Single-digit numbers are Armstrong numbers"
     (is (true? (armstrong-numbers/armstrong? 5)))))
 
-(deftest not-armstrong-number-10
+(deftest test-2d6db9dc-5bf8-4976-a90b-b2c2b9feba60
   (testing "There are no two-digit Armstrong numbers"
     (is (false? (armstrong-numbers/armstrong? 10)))))
 
-(deftest armstrong-number-153
+(deftest test-509c087f-e327-4113-a7d2-26a4e9d18283
   (testing "Three-digit number that is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 153)))))
 
-(deftest not-armstrong-number-100
+(deftest test-7154547d-c2ce-468d-b214-4cb953b870cf
   (testing "Three-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 100)))))
 
-(deftest armstrong-number-9474
+(deftest test-6bac5b7b-42e9-4ecb-a8b0-4832229aa103
   (testing "Four-digit number that is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 9474)))))
 
-(deftest not-armstrong-number-9475
+(deftest test-eed4b331-af80-45b5-a80b-19c9ea444b2e
   (testing "Four-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 9475)))))
 
-(deftest armstrong-number-9926315
+(deftest test-f971ced7-8d68-4758-aea1-d4194900b864
   (testing "Seven-digit number that is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 9926315)))))
 
-(deftest not-armstrong-number-9926314
+(deftest test-7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18
   (testing "Seven-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 9926314)))))
 
-(deftest armstrong-number-186709961001538790100634132976990
+(deftest test-5ee2fdf8-334e-4a46-bb8d-e5c19c02c148
   (testing "Armstrong number containing seven zeroes"
     (is (true? (armstrong-numbers/armstrong? 186709961001538790100634132976990)))))
 
-(deftest armstrong-number-115132219018763992565095597973971522401
+(deftest test-12ffbf10-307a-434e-b4ad-c925680e1dd4
   (testing "The largest and last Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 115132219018763992565095597973971522401)))))


### PR DESCRIPTION
Added the final two tests involving big integers. Without these tests, some solutions improperly relied on Java interop for exponentiation, which is incorrect since Java's exponentiation functions return floating-point numbers instead of integers, as required here. Additionally, without these tests, incorrect solutions using Java interop could pass all tests. This PR addresses both issues.

Also

* Updated the armstrong_numbers.clj starter file with a proper function template
* Explicitly check with `true?` and `false?` as `true` and `false` are the exact values expected to be returned by `armstrong?`
* Updated example solution to pass the new tests