### PR TITLE
Update leiningen's project.clj files to Clojure 1.11.1

### DIFF
--- a/exercises/concept/annalyns-infiltration/project.clj
+++ b/exercises/concept/annalyns-infiltration/project.clj
@@ -1,4 +1,4 @@
 (defproject annalyns-infiltration "0.1.0-SNAPSHOT"
   :description "annalyns-infiltration exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/annalyns-infiltration"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/bird-watcher/project.clj
+++ b/exercises/concept/bird-watcher/project.clj
@@ -1,4 +1,4 @@
 (defproject bird-watcher "0.1.0-SNAPSHOT"
   :description "bird-watcher exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/bird-watcher"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/cars-assemble/project.clj
+++ b/exercises/concept/cars-assemble/project.clj
@@ -1,4 +1,4 @@
 (defproject cars-assemble "0.1.0-SNAPSHOT"
   :description "cars-assemble exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/cars-assemble"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/coordinate-transformation/project.clj
+++ b/exercises/concept/coordinate-transformation/project.clj
@@ -1,4 +1,4 @@
 (defproject coordinate-transformation "0.1.0-SNAPSHOT"
   :description "coordinate-transformation exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/cars-assemble"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/elyses-destructured-enchantments/project.clj
+++ b/exercises/concept/elyses-destructured-enchantments/project.clj
@@ -1,4 +1,4 @@
 (defproject elyses-destructured-enchantments "0.1.0-SNAPSHOT"
   :description "elyses-destructured-enchantments exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/elyses-destructured-enchantments"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/international-calling-connoisseur/project.clj
+++ b/exercises/concept/international-calling-connoisseur/project.clj
@@ -1,4 +1,4 @@
 (defproject international-calling-connoisseur "0.1.0-SNAPSHOT"
   :description "international-calling-connoisseur exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/international-calling-connoisseur"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/log-levels/project.clj
+++ b/exercises/concept/log-levels/project.clj
@@ -1,4 +1,4 @@
 (defproject log-levels "0.1.0-SNAPSHOT"
   :description "log-levels exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/log-levels"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/lucians-luscious-lasagna/project.clj
+++ b/exercises/concept/lucians-luscious-lasagna/project.clj
@@ -1,4 +1,4 @@
 (defproject lucians-luscious-lasagna "0.1.0-SNAPSHOT"
   :description "lucians-luscious-lasagna exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/lucians-luscious-lasagna"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/concept/tracks-on-tracks-on-tracks/project.clj
+++ b/exercises/concept/tracks-on-tracks-on-tracks/project.clj
@@ -1,4 +1,4 @@
 (defproject tracks-on-tracks-on-tracks "0.1.0-SNAPSHOT"
   :description "tracks-on-tracks-on-tracks exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/tracks-on-tracks-on-tracks"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/accumulate/project.clj
+++ b/exercises/practice/accumulate/project.clj
@@ -1,4 +1,4 @@
 (defproject accumulate "0.1.0-SNAPSHOT"
   :description "accumulate exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/accumulate"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/acronym/project.clj
+++ b/exercises/practice/acronym/project.clj
@@ -1,4 +1,4 @@
 (defproject acronym "0.1.0-SNAPSHOT"
   :description "acronym exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/acronym"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/all-your-base/project.clj
+++ b/exercises/practice/all-your-base/project.clj
@@ -1,4 +1,4 @@
 (defproject all-your-base "0.1.0-SNAPSHOT"
   :description "all-your-base exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/all-your-base"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/allergies/project.clj
+++ b/exercises/practice/allergies/project.clj
@@ -1,4 +1,4 @@
 (defproject allergies "0.1.0-SNAPSHOT"
   :description "allergies exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/allergies"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/anagram/project.clj
+++ b/exercises/practice/anagram/project.clj
@@ -1,4 +1,4 @@
 (defproject anagram "0.1.0-SNAPSHOT"
   :description "anagram exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/anagram"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/armstrong-numbers/project.clj
+++ b/exercises/practice/armstrong-numbers/project.clj
@@ -1,4 +1,4 @@
 (defproject armstrong-numbers "0.1.0-SNAPSHOT"
   :description "armstrong-numbers exercise"
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/armstrong-numbers"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/atbash-cipher/project.clj
+++ b/exercises/practice/atbash-cipher/project.clj
@@ -1,4 +1,4 @@
 (defproject atbash-cipher "0.1.0-SNAPSHOT"
   :description "atbash-cipher exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/atbash-cipher"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/bank-account/project.clj
+++ b/exercises/practice/bank-account/project.clj
@@ -1,4 +1,4 @@
 (defproject bank-account "0.1.0-SNAPSHOT"
   :description "bank-account exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/bank-account"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/beer-song/project.clj
+++ b/exercises/practice/beer-song/project.clj
@@ -1,4 +1,4 @@
 (defproject beer-song "0.1.0-SNAPSHOT"
   :description "beer-song exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/beer-song"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/binary-search-tree/project.clj
+++ b/exercises/practice/binary-search-tree/project.clj
@@ -1,4 +1,4 @@
 (defproject binary-search-tree "0.1.0-SNAPSHOT"
   :description "binary-search-tree exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/binary-search-tree"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/binary-search/project.clj
+++ b/exercises/practice/binary-search/project.clj
@@ -1,4 +1,4 @@
 (defproject binary-search "0.1.0-SNAPSHOT"
   :description "binary-search exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/binary-search"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/binary/project.clj
+++ b/exercises/practice/binary/project.clj
@@ -1,4 +1,4 @@
 (defproject binary "0.1.0-SNAPSHOT"
   :description "binary exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/binary"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/bob/project.clj
+++ b/exercises/practice/bob/project.clj
@@ -1,4 +1,4 @@
 (defproject bob "0.1.0-SNAPSHOT"
   :description "bob exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/bob"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/change/project.clj
+++ b/exercises/practice/change/project.clj
@@ -3,4 +3,4 @@
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/change"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/clock/project.clj
+++ b/exercises/practice/clock/project.clj
@@ -1,4 +1,4 @@
 (defproject clock "0.1.0-SNAPSHOT"
   :description "clock exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/clock"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/collatz-conjecture/project.clj
+++ b/exercises/practice/collatz-conjecture/project.clj
@@ -1,4 +1,4 @@
 (defproject collatz-conjecture "0.1.0-SNAPSHOT"
   :description "collatz-conjecture exercise"
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/collatz-conjecture"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/complex-numbers/project.clj
+++ b/exercises/practice/complex-numbers/project.clj
@@ -1,4 +1,4 @@
 (defproject complex-numbers "0.1.0-SNAPSHOT"
   :description "complex-numbers exercise"
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/complex-numbers"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/crypto-square/project.clj
+++ b/exercises/practice/crypto-square/project.clj
@@ -1,4 +1,4 @@
 (defproject crypto-square "0.1.0-SNAPSHOT"
   :description "crypto-square exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/crypto-square"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/diamond/project.clj
+++ b/exercises/practice/diamond/project.clj
@@ -1,4 +1,4 @@
 (defproject diamond "0.1.0-SNAPSHOT"
   :description "diamond exercise."
   :url "https://github.com/exercism/xclojure/tree/master/exercises/diamond"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/difference-of-squares/project.clj
+++ b/exercises/practice/difference-of-squares/project.clj
@@ -1,4 +1,4 @@
 (defproject difference-of-squares "0.1.0-SNAPSHOT"
   :description "difference-of-squares exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/difference-of-squares"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/dominoes/project.clj
+++ b/exercises/practice/dominoes/project.clj
@@ -1,4 +1,4 @@
 (defproject dominoes "0.1.0-SNAPSHOT"
   :description "dominoes exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/dominoes"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/eliuds-eggs/project.clj
+++ b/exercises/practice/eliuds-eggs/project.clj
@@ -1,4 +1,4 @@
 (defproject eliuds-eggs "0.1.0-SNAPSHOT"
   :description "eliuds-eggs exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/eliuds-eggs"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/etl/project.clj
+++ b/exercises/practice/etl/project.clj
@@ -1,4 +1,4 @@
 (defproject etl "0.1.0-SNAPSHOT"
   :description "etl exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/etl"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/flatten-array/project.clj
+++ b/exercises/practice/flatten-array/project.clj
@@ -1,4 +1,4 @@
 (defproject flatten-array "0.1.0-SNAPSHOT"
   :description "flatten-array exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/flatten-array"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/gigasecond/project.clj
+++ b/exercises/practice/gigasecond/project.clj
@@ -1,4 +1,4 @@
 (defproject gigasecond "0.1.0-SNAPSHOT"
   :description "gigasecond exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/gigasecond"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/go-counting/project.clj
+++ b/exercises/practice/go-counting/project.clj
@@ -1,4 +1,4 @@
 (defproject go-counting "0.1.0-SNAPSHOT"
   :description "go-counting exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/go-counting"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/grade-school/project.clj
+++ b/exercises/practice/grade-school/project.clj
@@ -1,4 +1,4 @@
 (defproject grade-school "0.1.0-SNAPSHOT"
   :description "grade-school exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/grade-school"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/grains/project.clj
+++ b/exercises/practice/grains/project.clj
@@ -1,4 +1,4 @@
 (defproject grains "0.1.0-SNAPSHOT"
   :description "grains exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/grains"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/hamming/project.clj
+++ b/exercises/practice/hamming/project.clj
@@ -1,4 +1,4 @@
 (defproject hamming "0.1.0-SNAPSHOT"
   :description "hamming exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/hamming"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/hello-world/project.clj
+++ b/exercises/practice/hello-world/project.clj
@@ -1,4 +1,4 @@
 (defproject hello-world "0.1.0-SNAPSHOT"
   :description "hello-world exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/hello-world"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/hexadecimal/project.clj
+++ b/exercises/practice/hexadecimal/project.clj
@@ -1,4 +1,4 @@
 (defproject hexadecimal "0.1.0-SNAPSHOT"
   :description "hexadecimal exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/hexadecimal"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/isbn-verifier/project.clj
+++ b/exercises/practice/isbn-verifier/project.clj
@@ -1,4 +1,4 @@
 (defproject isbn-verifier "0.1.0-SNAPSHOT"
   :description "isbn-verifier xercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/isbn-verifier"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/isogram/project.clj
+++ b/exercises/practice/isogram/project.clj
@@ -1,4 +1,4 @@
 (defproject isogram "0.1.0-SNAPSHOT"
   :description "isogram exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/isogram"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/kindergarten-garden/project.clj
+++ b/exercises/practice/kindergarten-garden/project.clj
@@ -1,4 +1,4 @@
 (defproject kindergarten-garden "0.1.0-SNAPSHOT"
   :description "kindergarten-garden exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/kindergarten-garden"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/largest-series-product/project.clj
+++ b/exercises/practice/largest-series-product/project.clj
@@ -1,4 +1,4 @@
 (defproject largest-series-product "0.1.0-SNAPSHOT"
   :description "largest-series-product exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/largest-series-product"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/leap/project.clj
+++ b/exercises/practice/leap/project.clj
@@ -1,4 +1,4 @@
 (defproject leap "0.1.0-SNAPSHOT"
   :description "leap exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/leap"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/list-ops/project.clj
+++ b/exercises/practice/list-ops/project.clj
@@ -1,4 +1,4 @@
 (defproject list-ops "0.1.0-SNAPSHOT"
   :description "list-ops exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/list-ops"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/luhn/project.clj
+++ b/exercises/practice/luhn/project.clj
@@ -1,4 +1,4 @@
 (defproject luhn "0.1.0-SNAPSHOT"
   :description "luhn exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/luhn"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/matching-brackets/project.clj
+++ b/exercises/practice/matching-brackets/project.clj
@@ -1,4 +1,4 @@
 (defproject matching-brackets "0.1.0-SNAPSHOT"
   :description "matching-brackets exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/matching-brackets"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/meetup/project.clj
+++ b/exercises/practice/meetup/project.clj
@@ -1,4 +1,4 @@
 (defproject meetup "0.1.0-SNAPSHOT"
   :description "meetup exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/meetup"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/minesweeper/project.clj
+++ b/exercises/practice/minesweeper/project.clj
@@ -1,4 +1,4 @@
 (defproject minesweeper "0.1.0-SNAPSHOT"
   :description "minesweeper exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/minesweeper"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/nth-prime/project.clj
+++ b/exercises/practice/nth-prime/project.clj
@@ -1,4 +1,4 @@
 (defproject nth-prime "0.1.0-SNAPSHOT"
   :description "nth-prime exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/nth-prime"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/nucleotide-count/project.clj
+++ b/exercises/practice/nucleotide-count/project.clj
@@ -1,4 +1,4 @@
 (defproject nucleotide-count "0.1.0-SNAPSHOT"
   :description "nucleotide-count exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/nucleotide-count"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/octal/project.clj
+++ b/exercises/practice/octal/project.clj
@@ -1,4 +1,4 @@
 (defproject octal "0.1.0-SNAPSHOT"
   :description "octal exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/octal"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/pangram/project.clj
+++ b/exercises/practice/pangram/project.clj
@@ -3,4 +3,4 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/pascals-triangle/project.clj
+++ b/exercises/practice/pascals-triangle/project.clj
@@ -1,4 +1,4 @@
 (defproject pascals-triangle "0.1.0-SNAPSHOT"
   :description "pascal's triangle exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/pascals-triangle"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/perfect-numbers/project.clj
+++ b/exercises/practice/perfect-numbers/project.clj
@@ -1,4 +1,4 @@
 (defproject perfect-numbers "0.1.0-SNAPSHOT"
   :description "perfect-numbers exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/perfect-numbers"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/phone-number/project.clj
+++ b/exercises/practice/phone-number/project.clj
@@ -1,4 +1,4 @@
 (defproject phone-number "0.1.0-SNAPSHOT"
   :description "phone-number exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/phone-number"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/pig-latin/project.clj
+++ b/exercises/practice/pig-latin/project.clj
@@ -1,4 +1,4 @@
 (defproject pig-latin "0.1.0-SNAPSHOT"
   :description "pig latin exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/pig-latin"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/poker/project.clj
+++ b/exercises/practice/poker/project.clj
@@ -1,4 +1,4 @@
 (defproject poker "0.1.0-SNAPSHOT"
   :description "poker exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/poker"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/pov/project.clj
+++ b/exercises/practice/pov/project.clj
@@ -1,2 +1,2 @@
 (defproject pov "0.1.0-SNAPSHOT"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/prime-factors/project.clj
+++ b/exercises/practice/prime-factors/project.clj
@@ -1,4 +1,4 @@
 (defproject prime-factors "0.1.0-SNAPSHOT"
   :description "prime-factors exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/prime-factors"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/protein-translation/project.clj
+++ b/exercises/practice/protein-translation/project.clj
@@ -1,4 +1,4 @@
 (defproject protein-translation "0.1.0-SNAPSHOT"
   :description "protein translation exercise."
   :url "https://github.com/exercism/xclojure/tree/master/exercises/protein-translation"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/proverb/project.clj
+++ b/exercises/practice/proverb/project.clj
@@ -1,4 +1,4 @@
 (defproject proverb "0.1.0-SNAPSHOT"
   :description "proverb exercise."
   :url "https://github.com/exercism/xclojure/tree/master/exercises/proverb"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/queen-attack/project.clj
+++ b/exercises/practice/queen-attack/project.clj
@@ -1,4 +1,4 @@
 (defproject queen-attack "0.1.0-SNAPSHOT"
   :description "queen-attack exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/queen-attack"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/raindrops/project.clj
+++ b/exercises/practice/raindrops/project.clj
@@ -1,4 +1,4 @@
 (defproject raindrops "0.1.0-SNAPSHOT"
   :description "raindrops exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/raindrops"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/reverse-string/project.clj
+++ b/exercises/practice/reverse-string/project.clj
@@ -1,4 +1,4 @@
 (defproject reverse-string "0.1.0-SNAPSHOT"
   :description "reverse-string exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/reverse-string"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/rna-transcription/project.clj
+++ b/exercises/practice/rna-transcription/project.clj
@@ -1,4 +1,4 @@
 (defproject rna-transcription "0.1.0-SNAPSHOT"
   :description "rna-transcription exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/rna-transcription"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/robot-name/project.clj
+++ b/exercises/practice/robot-name/project.clj
@@ -1,4 +1,4 @@
 (defproject robot-name "0.1.0-SNAPSHOT"
   :description "robot-name exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/robot-name"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/robot-simulator/project.clj
+++ b/exercises/practice/robot-simulator/project.clj
@@ -1,4 +1,4 @@
 (defproject robot-simulator "0.1.0-SNAPSHOT"
   :description "robot-simulator exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/robot-simulator"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/roman-numerals/project.clj
+++ b/exercises/practice/roman-numerals/project.clj
@@ -1,4 +1,4 @@
 (defproject roman-numerals "0.1.0-SNAPSHOT"
   :description "roman-numerals exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/roman-numerals"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/rotational-cipher/project.clj
+++ b/exercises/practice/rotational-cipher/project.clj
@@ -1,4 +1,4 @@
 (defproject rotational-cipher "0.1.0-SNAPSHOT"
   :description "rotational cipher exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/rotational-cipher"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/run-length-encoding/project.clj
+++ b/exercises/practice/run-length-encoding/project.clj
@@ -1,4 +1,4 @@
 (defproject run-length-encoding "0.1.0-SNAPSHOT"
   :description "run-length-encoding exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/run-length-encoding"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/say/project.clj
+++ b/exercises/practice/say/project.clj
@@ -1,4 +1,4 @@
 (defproject say "0.1.0-SNAPSHOT"
   :description "say exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/say"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/scrabble-score/project.clj
+++ b/exercises/practice/scrabble-score/project.clj
@@ -1,4 +1,4 @@
 (defproject scrabble-score "0.1.0-SNAPSHOT"
   :description "scrabble-score exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/scrabble-score"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/secret-handshake/project.clj
+++ b/exercises/practice/secret-handshake/project.clj
@@ -1,4 +1,4 @@
 (defproject secret-handshake "0.1.0-SNAPSHOT"
   :description "secret-handshake exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/secret-handshake"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/series/project.clj
+++ b/exercises/practice/series/project.clj
@@ -1,4 +1,4 @@
 (defproject series "0.1.0-SNAPSHOT"
   :description "series exercise"
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/series"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/sieve/project.clj
+++ b/exercises/practice/sieve/project.clj
@@ -1,4 +1,4 @@
 (defproject sieve "0.1.0-SNAPSHOT"
   :description "sieve exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/sieve"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/space-age/project.clj
+++ b/exercises/practice/space-age/project.clj
@@ -1,4 +1,4 @@
 (defproject space-age "0.1.0-SNAPSHOT"
   :description "space-age exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/space-age"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/spiral-matrix/project.clj
+++ b/exercises/practice/spiral-matrix/project.clj
@@ -1,4 +1,4 @@
 (defproject spiral-matrix "0.1.0-SNAPSHOT"
   :description "spiral-matrix exercise"
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/spiral-matrix"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/strain/project.clj
+++ b/exercises/practice/strain/project.clj
@@ -1,4 +1,4 @@
 (defproject strain "0.1.0-SNAPSHOT"
   :description "strain exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/strain"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/sublist/project.clj
+++ b/exercises/practice/sublist/project.clj
@@ -1,4 +1,4 @@
 (defproject sublist "0.1.0-SNAPSHOT"
   :description "sublist exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/sublist"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/sum-of-multiples/project.clj
+++ b/exercises/practice/sum-of-multiples/project.clj
@@ -1,4 +1,4 @@
 (defproject sum-of-multiples "0.1.0-SNAPSHOT"
   :description "sum-of-multiples exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/sum-of-multiples"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/triangle/project.clj
+++ b/exercises/practice/triangle/project.clj
@@ -1,4 +1,4 @@
 (defproject triangle "0.1.0-SNAPSHOT"
   :description "triangle exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/triangle"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/trinary/project.clj
+++ b/exercises/practice/trinary/project.clj
@@ -1,4 +1,4 @@
 (defproject trinary "0.1.0-SNAPSHOT"
   :description "trinary exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/trinary"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/two-fer/project.clj
+++ b/exercises/practice/two-fer/project.clj
@@ -1,4 +1,4 @@
 (defproject two-fer "0.1.0-SNAPSHOT"
   :description "two-fer exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/two-fer"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/word-count/project.clj
+++ b/exercises/practice/word-count/project.clj
@@ -1,4 +1,4 @@
 (defproject word-count "0.1.0-SNAPSHOT"
   :description "word-count exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/word-count"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/wordy/project.clj
+++ b/exercises/practice/wordy/project.clj
@@ -1,4 +1,4 @@
 (defproject word-count "0.1.0-SNAPSHOT"
   :description "wordy exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/wordy"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/yacht/project.clj
+++ b/exercises/practice/yacht/project.clj
@@ -1,4 +1,4 @@
 (defproject yacht "0.1.0-SNAPSHOT"
   :description "yacht exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/yacht"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])

--- a/exercises/practice/zipper/project.clj
+++ b/exercises/practice/zipper/project.clj
@@ -1,4 +1,4 @@
 (defproject zipper "0.1.0-SNAPSHOT"
   :description "zipper exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/practice/zipper"
-  :dependencies [[org.clojure/clojure "1.10.0"]])
+  :dependencies [[org.clojure/clojure "1.11.1"]])


### PR DESCRIPTION
1.10.0 is quite outdated at this point. It's worth updating all config files to Clojure 1.11.1 since there's new functionality that can be useful, like the `clojure.math` namespace for instance.