### PR TITLE
Remove uuids from test functions

### DIFF
--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -1,5 +1,5 @@
 (ns armstrong-numbers-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest testing is]]
             armstrong-numbers))
 
 (deftest armstrong?_test_1

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.clj
@@ -2,46 +2,46 @@
   (:require [clojure.test :refer [deftest is testing]]
             armstrong-numbers))
 
-(deftest test-c1ed103c-258d-45b2-be73-d8c6d9580c7b
+(deftest armstrong?_test_1
   (testing "Zero is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 0)))))
 
-(deftest test-579e8f03-9659-4b85-a1a2-d64350f6b17a
+(deftest armstrong?_test_2
   (testing "Single-digit numbers are Armstrong numbers"
     (is (true? (armstrong-numbers/armstrong? 5)))))
 
-(deftest test-2d6db9dc-5bf8-4976-a90b-b2c2b9feba60
+(deftest armstrong?_test_3
   (testing "There are no two-digit Armstrong numbers"
     (is (false? (armstrong-numbers/armstrong? 10)))))
 
-(deftest test-509c087f-e327-4113-a7d2-26a4e9d18283
+(deftest armstrong?_test_4
   (testing "Three-digit number that is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 153)))))
 
-(deftest test-7154547d-c2ce-468d-b214-4cb953b870cf
+(deftest armstrong?_test_5
   (testing "Three-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 100)))))
 
-(deftest test-6bac5b7b-42e9-4ecb-a8b0-4832229aa103
+(deftest armstrong?_test_6
   (testing "Four-digit number that is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 9474)))))
 
-(deftest test-eed4b331-af80-45b5-a80b-19c9ea444b2e
+(deftest armstrong?_test_7
   (testing "Four-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 9475)))))
 
-(deftest test-f971ced7-8d68-4758-aea1-d4194900b864
+(deftest armstrong?_test_8
   (testing "Seven-digit number that is an Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 9926315)))))
 
-(deftest test-7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18
+(deftest armstrong?_test_9
   (testing "Seven-digit number that is not an Armstrong number"
     (is (false? (armstrong-numbers/armstrong? 9926314)))))
 
-(deftest test-5ee2fdf8-334e-4a46-bb8d-e5c19c02c148
+(deftest armstrong?_test_10
   (testing "Armstrong number containing seven zeroes"
     (is (true? (armstrong-numbers/armstrong? 186709961001538790100634132976990)))))
 
-(deftest test-12ffbf10-307a-434e-b4ad-c925680e1dd4
+(deftest armstrong?_test_11
   (testing "The largest and last Armstrong number"
     (is (true? (armstrong-numbers/armstrong? 115132219018763992565095597973971522401)))))

--- a/exercises/practice/dominoes/test/dominoes_test.clj
+++ b/exercises/practice/dominoes/test/dominoes_test.clj
@@ -2,54 +2,54 @@
   (:require [clojure.test :refer [deftest testing is]]
             dominoes))
 
-(deftest test-31a673f2-5e54-49fe-bd79-1c1dae476c9c
+(deftest can-chain?_test_1
   (testing "empty input = empty output"
     (is (true? (dominoes/can-chain? [])))))
 
-(deftest test-4f99b933-367b-404b-8c6d-36d5923ee476
+(deftest can-chain?_test_2
   (testing "singleton input = singleton output"
     (is (true? (dominoes/can-chain? [[1 1]])))))
 
-(deftest test-91122d10-5ec7-47cb-b759-033756375869
+(deftest can-chain?_test_3
   (testing "singleton that can't be chained"
     (is (false? (dominoes/can-chain? [[1 2]])))))
 
-(deftest test-be8bc26b-fd3d-440b-8e9f-d698a0623be3
+(deftest can-chain?_test_4
   (testing "three elements"
     (is (true? (dominoes/can-chain?  [[1 2] [3 1] [2 3]])))))
 
-(deftest test-99e615c6-c059-401c-9e87-ad7af11fea5c
+(deftest can-chain?_test_5
   (testing "can reverse dominoes"
     (is (true? (dominoes/can-chain? [[1 2] [1 3] [2 3]])))))
 
-(deftest test-51f0c291-5d43-40c5-b316-0429069528c9
+(deftest can-chain?_test_6
   (testing "can't be chained"
     (is (false? (dominoes/can-chain? [[1 2] [4 1] [2 3]])))))
 
-(deftest test-9a75e078-a025-4c23-8c3a-238553657f39
+(deftest can-chain?_test_7
   (testing "disconnected - simple"
     (is (false? (dominoes/can-chain? [[1 1] [2 2]])))))
 
-(deftest test-0da0c7fe-d492-445d-b9ef-1f111f07a301
+(deftest can-chain?_test_8
   (testing "disconnected - double loop"
     (is (false? (dominoes/can-chain? [[1 2] [2 1] [3 4] [4 3]])))))
 
-(deftest test-b6087ff0-f555-4ea0-a71c-f9d707c5994a
+(deftest can-chain?_test_9
   (testing "disconnected - single isolated"
     (is (false? (dominoes/can-chain? [[1 2] [2 3] [3 1] [4 4]])))))
 
-(deftest test-2174fbdc-8b48-4bac-9914-8090d06ef978
+(deftest can-chain?_test_10
   (testing "need backtrack"
     (is (true? (dominoes/can-chain? [[1 2] [2 3] [3 1] [2 4] [2 4]])))))
 
-(deftest test-167bb480-dfd1-4318-a20d-4f90adb4a09f
+(deftest can-chain?_test_11
   (testing "separate loops"
     (is (true? (dominoes/can-chain? [[1 2] [2 3] [3 1] [1 1] [2 2] [3 3]])))))
 
-(deftest test-cd061538-6046-45a7-ace9-6708fe8f6504
+(deftest can-chain?_test_12
   (testing "nine elements"
     (is (true? (dominoes/can-chain? [[1 2] [5 3] [3 1] [1 2] [2 4] [1 6] [2 3] [3 4] [5 6]])))))
 
-(deftest test-44704c7c-3adb-4d98-bd30-f45527cf8b49
+(deftest can-chain?_test_13
   (testing "separate three-domino loops"
     (is (false? (dominoes/can-chain?  [[1 2] [2 3] [3 1] [4 5] [5 6] [6 4]])))))

--- a/exercises/practice/dominoes/test/dominoes_test.clj
+++ b/exercises/practice/dominoes/test/dominoes_test.clj
@@ -3,53 +3,53 @@
             dominoes))
 
 (deftest test-31a673f2-5e54-49fe-bd79-1c1dae476c9c
-  (testing "Empty input = empty output"
+  (testing "empty input = empty output"
     (is (true? (dominoes/can-chain? [])))))
 
 (deftest test-4f99b933-367b-404b-8c6d-36d5923ee476
-  (testing "Singleton input = singleton output"
+  (testing "singleton input = singleton output"
     (is (true? (dominoes/can-chain? [[1 1]])))))
 
 (deftest test-91122d10-5ec7-47cb-b759-033756375869
-  (testing "Singleton that can't be chained"
+  (testing "singleton that can't be chained"
     (is (false? (dominoes/can-chain? [[1 2]])))))
 
 (deftest test-be8bc26b-fd3d-440b-8e9f-d698a0623be3
-  (testing "Three elements"
+  (testing "three elements"
     (is (true? (dominoes/can-chain?  [[1 2] [3 1] [2 3]])))))
 
 (deftest test-99e615c6-c059-401c-9e87-ad7af11fea5c
-  (testing "Can reverse dominoes"
+  (testing "can reverse dominoes"
     (is (true? (dominoes/can-chain? [[1 2] [1 3] [2 3]])))))
 
 (deftest test-51f0c291-5d43-40c5-b316-0429069528c9
-  (testing "Can't be chained"
+  (testing "can't be chained"
     (is (false? (dominoes/can-chain? [[1 2] [4 1] [2 3]])))))
 
 (deftest test-9a75e078-a025-4c23-8c3a-238553657f39
-  (testing "Disconnected - simple"
+  (testing "disconnected - simple"
     (is (false? (dominoes/can-chain? [[1 1] [2 2]])))))
 
 (deftest test-0da0c7fe-d492-445d-b9ef-1f111f07a301
-  (testing "Disconnected - double loop"
+  (testing "disconnected - double loop"
     (is (false? (dominoes/can-chain? [[1 2] [2 1] [3 4] [4 3]])))))
 
 (deftest test-b6087ff0-f555-4ea0-a71c-f9d707c5994a
-  (testing "Disconnected - single isolated"
+  (testing "disconnected - single isolated"
     (is (false? (dominoes/can-chain? [[1 2] [2 3] [3 1] [4 4]])))))
 
 (deftest test-2174fbdc-8b48-4bac-9914-8090d06ef978
-  (testing "Need backtrack"
+  (testing "need backtrack"
     (is (true? (dominoes/can-chain? [[1 2] [2 3] [3 1] [2 4] [2 4]])))))
 
 (deftest test-167bb480-dfd1-4318-a20d-4f90adb4a09f
-  (testing "Separate loops"
+  (testing "separate loops"
     (is (true? (dominoes/can-chain? [[1 2] [2 3] [3 1] [1 1] [2 2] [3 3]])))))
 
 (deftest test-cd061538-6046-45a7-ace9-6708fe8f6504
-  (testing "Nine elements"
+  (testing "nine elements"
     (is (true? (dominoes/can-chain? [[1 2] [5 3] [3 1] [1 2] [2 4] [1 6] [2 3] [3 4] [5 6]])))))
 
 (deftest test-44704c7c-3adb-4d98-bd30-f45527cf8b49
-  (testing "Separate three-domino loops"
+  (testing "separate three-domino loops"
     (is (false? (dominoes/can-chain?  [[1 2] [2 3] [3 1] [4 5] [5 6] [6 4]])))))

--- a/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.clj
+++ b/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.clj
@@ -2,87 +2,87 @@
   (:require [clojure.test :refer [deftest testing is]]
             kindergarten-garden))
 
-(deftest test-1fc316ed-17ab-4fba-88ef-3ae78296b692
+(deftest garden_test_1
   (testing "partial garden -> garden with single student"
     (is (= [:radishes :clover :grass :grass]
            (:alice (kindergarten-garden/garden "RC\nGG"))))))
 
-(deftest test-acd19dc1-2200-4317-bc2a-08f021276b40
+(deftest garden_test_2
   (testing "partial garden -> different garden with single student"
     (is (= [:violets :clover :radishes :clover]
            (:alice (kindergarten-garden/garden "VC\nRC"))))))
 
-(deftest test-c376fcc8-349c-446c-94b0-903947315757
+(deftest garden_test_3
   (testing "partial garden -> garden with two students"
     (is (= [:clover :grass :radishes :clover]
            (:bob (kindergarten-garden/garden "VVCG\nVVRC"))))))
 
-(deftest test-2d620f45-9617-4924-9d27-751c80d17db9
+(deftest garden_test_4
   (testing "partial garden -> multiple students for the same garden with three students -> second student's garden"
     (is (= [:clover :clover :clover :clover]
            (:bob (kindergarten-garden/garden "VVCCGG\nVVCCGG"))))))
 
-(deftest test-57712331-4896-4364-89f8-576421d69c44
+(deftest garden_test_5
   (testing "partial garden -> multiple students for the same garden with three students -> third student's garden"
     (is (= [:grass :grass :grass :grass]
            (:charlie (kindergarten-garden/garden "VVCCGG\nVVCCGG"))))))
 
-(deftest test-149b4290-58e1-40f2-8ae4-8b87c46e765b
+(deftest garden_test_6
   (testing "full garden -> for Alice first student's garden"
     (is (= [:violets :radishes :violets :radishes]
            (:alice (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-ba25dbbc-10bd-4a37-b18e-f89ecd098a5e
+(deftest garden_test_7
   (testing "full garden -> for Bob second student's garden"
     (is (= [:clover :grass :clover :clover]
            (:bob (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-566b621b-f18e-4c5f-873e-be30544b838c
+(deftest garden_test_8
   (testing "full garden -> for Charlie"
     (is (= [:violets :violets :clover :grass]
            (:charlie (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-3ad3df57-dd98-46fc-9269-1877abf612aa
+(deftest garden_test_9
   (testing "full garden -> for David"
     (is (= [:radishes :violets :clover :radishes]
            (:david (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-0f0a55d1-9710-46ed-a0eb-399ba8c72db2
+(deftest garden_test_10
   (testing "full garden -> for Eve"
     (is (= [:clover :grass :radishes :grass]
            (:eve (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-a7e80c90-b140-4ea1-aee3-f4625365c9a4
+(deftest garden_test_11
   (testing "full garden -> for Fred"
     (is (= [:grass :clover :violets :clover]
            (:fred (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-9d94b273-2933-471b-86e8-dba68694c615
+(deftest garden_test_12
   (testing "full garden -> for Ginny"
     (is (= [:clover :grass :grass :clover]
            (:ginny (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-f55bc6c2-ade8-4844-87c4-87196f1b7258
+(deftest garden_test_13
   (testing "full garden -> for Harriet"
     (is (= [:violets :radishes :radishes :violets]
            (:harriet (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-759070a3-1bb1-4dd4-be2c-7cce1d7679ae
+(deftest garden_test_14
   (testing "full garden -> for Ileana"
     (is (= [:grass :clover :violets :clover]
            (:ileana (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-78578123-2755-4d4a-9c7d-e985b8dda1c6
+(deftest garden_test_15
   (testing "full garden -> for Joseph"
     (is (= [:violets :clover :violets :grass]
            (:joseph (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-6bb66df7-f433-41ab-aec2-3ead6e99f65b
+(deftest garden_test_16
   (testing "full garden -> for Kincaid second to last student's garden"
     (is (= [:grass :clover :clover :grass]
            (:kincaid (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
-(deftest test-d7edec11-6488-418a-94e6-ed509e0fa7eb
+(deftest garden_test_17
   (testing "full garden -> for Larry last student's garden"
     (is (= [:grass :violets :clover :violets]
            (:larry (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))

--- a/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.clj
+++ b/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.clj
@@ -3,86 +3,86 @@
             kindergarten-garden))
 
 (deftest test-1fc316ed-17ab-4fba-88ef-3ae78296b692
-  (testing "Partial garden -> Garden with single student"
+  (testing "partial garden -> garden with single student"
     (is (= [:radishes :clover :grass :grass]
            (:alice (kindergarten-garden/garden "RC\nGG"))))))
 
 (deftest test-acd19dc1-2200-4317-bc2a-08f021276b40
-  (testing "Partial garden -> Different garden with single student"
+  (testing "partial garden -> different garden with single student"
     (is (= [:violets :clover :radishes :clover]
            (:alice (kindergarten-garden/garden "VC\nRC"))))))
 
 (deftest test-c376fcc8-349c-446c-94b0-903947315757
-  (testing "Partial garden -> Garden with two students"
+  (testing "partial garden -> garden with two students"
     (is (= [:clover :grass :radishes :clover]
            (:bob (kindergarten-garden/garden "VVCG\nVVRC"))))))
 
 (deftest test-2d620f45-9617-4924-9d27-751c80d17db9
-  (testing "Partial garden -> Multiple students for the same garden with three students -> Second student's garden"
+  (testing "partial garden -> multiple students for the same garden with three students -> second student's garden"
     (is (= [:clover :clover :clover :clover]
            (:bob (kindergarten-garden/garden "VVCCGG\nVVCCGG"))))))
 
 (deftest test-57712331-4896-4364-89f8-576421d69c44
-  (testing "Partial garden -> Multiple students for the same garden with three students -> Third student's garden"
+  (testing "partial garden -> multiple students for the same garden with three students -> third student's garden"
     (is (= [:grass :grass :grass :grass]
            (:charlie (kindergarten-garden/garden "VVCCGG\nVVCCGG"))))))
 
 (deftest test-149b4290-58e1-40f2-8ae4-8b87c46e765b
-  (testing "Full garden -> For Alice first student's garden"
+  (testing "full garden -> for Alice first student's garden"
     (is (= [:violets :radishes :violets :radishes]
            (:alice (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-ba25dbbc-10bd-4a37-b18e-f89ecd098a5e
-  (testing "Full garden -> For Bob second student's garden"
+  (testing "full garden -> for Bob second student's garden"
     (is (= [:clover :grass :clover :clover]
            (:bob (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-566b621b-f18e-4c5f-873e-be30544b838c
-  (testing "Full garden -> For Charlie"
+  (testing "full garden -> for Charlie"
     (is (= [:violets :violets :clover :grass]
            (:charlie (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-3ad3df57-dd98-46fc-9269-1877abf612aa
-  (testing "Full garden -> For David"
+  (testing "full garden -> for David"
     (is (= [:radishes :violets :clover :radishes]
            (:david (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-0f0a55d1-9710-46ed-a0eb-399ba8c72db2
-  (testing "Full garden -> For Eve"
+  (testing "full garden -> for Eve"
     (is (= [:clover :grass :radishes :grass]
            (:eve (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-a7e80c90-b140-4ea1-aee3-f4625365c9a4
-  (testing "Full garden -> For Fred"
+  (testing "full garden -> for Fred"
     (is (= [:grass :clover :violets :clover]
            (:fred (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-9d94b273-2933-471b-86e8-dba68694c615
-  (testing "Full garden -> For Ginny"
+  (testing "full garden -> for Ginny"
     (is (= [:clover :grass :grass :clover]
            (:ginny (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-f55bc6c2-ade8-4844-87c4-87196f1b7258
-  (testing "Full garden -> For Harriet"
+  (testing "full garden -> for Harriet"
     (is (= [:violets :radishes :radishes :violets]
            (:harriet (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-759070a3-1bb1-4dd4-be2c-7cce1d7679ae
-  (testing "Full garden -> For Ileana"
+  (testing "full garden -> for Ileana"
     (is (= [:grass :clover :violets :clover]
            (:ileana (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-78578123-2755-4d4a-9c7d-e985b8dda1c6
-  (testing "Full garden -> For Joseph"
+  (testing "full garden -> for Joseph"
     (is (= [:violets :clover :violets :grass]
            (:joseph (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-6bb66df7-f433-41ab-aec2-3ead6e99f65b
-  (testing "Full garden -> For Kincaid second to last student's garden"
+  (testing "full garden -> for Kincaid second to last student's garden"
     (is (= [:grass :clover :clover :grass]
            (:kincaid (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))
 
 (deftest test-d7edec11-6488-418a-94e6-ed509e0fa7eb
-  (testing "Full garden -> For Larry last student's garden"
+  (testing "full garden -> for Larry last student's garden"
     (is (= [:grass :violets :clover :violets]
            (:larry (kindergarten-garden/garden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"))))))

--- a/exercises/practice/list-ops/test/list_ops_test.clj
+++ b/exercises/practice/list-ops/test/list_ops_test.clj
@@ -2,90 +2,90 @@
   (:require [clojure.test :refer [deftest testing is]]
              list-ops))
 
-(deftest test-485b9452-bf94-40f7-a3db-c3cf4850066a
+(deftest append_test_1
   (testing "append entries to a vector and return the new vector -> empty vectors"
     (is (= [] (list-ops/append [] [])))))
 
-(deftest test-2c894696-b609-4569-b149-8672134d340a
+(deftest append_test_2
   (testing "append entries to a vector and return the new vector -> vector to empty vector"
     (is (= [1 2 3 4] (list-ops/append [] [1 2 3 4])))))
 
-(deftest test-e842efed-3bf6-4295-b371-4d67a4fdf19c
+(deftest append_test_3
   (testing "append entries to a vector and return the new vector -> empty vector to vector"
     (is (= [1 2 3 4] (list-ops/append [1 2 3 4] [])))))
 
-(deftest test-71dcf5eb-73ae-4a0e-b744-a52ee387922f
+(deftest append_test_4
   (testing "append entries to a vector and return the new vector -> non-empty vectors"
     (is (= [1 2 2 3 4 5] (list-ops/append [1 2] [2 3 4 5])))))
 
-(deftest test-28444355-201b-4af2-a2f6-5550227bde21
+(deftest concatenate_test_1
   (testing "concatenate a vector of vectors -> empty vector"
     (is (= [] (list-ops/concatenate [])))))
 
-(deftest test-331451c1-9573-42a1-9869-2d06e3b389a9
+(deftest concatenate_test_2
   (testing "concatenate a vector of vectors -> vector of vectors"
     (is (= [1 2 3 4 5 6] (list-ops/concatenate [[1 2] [3] [] [4 5 6]])))))
 
-(deftest test-d6ecd72c-197f-40c3-89a4-aa1f45827e09
+(deftest concatenate_test_3
   (testing "concatenate a vector of vectors -> vector of nested vectors"
     (is (= [[1] [2] [3] [] [4 5 6]] (list-ops/concatenate [[[1] [2]] [[3]] [[]] [[4 5 6]]])))))
 
-(deftest test-0524fba8-3e0f-4531-ad2b-f7a43da86a16
+(deftest select-if_test_1
   (testing "filter vector returning only values that satisfy the filter function -> empty vector"
     (is (= [] (list-ops/select-if (fn [x] (= (mod x 2) 1)) [])))))
 
-(deftest test-88494bd5-f520-4edb-8631-88e415b62d24
+(deftest select-if_test_2
   (testing "filter vector returning only values that satisfy the filter function -> non-empty vector"
     (is (= [1 3 5] (list-ops/select-if (fn [x] (= (mod x 2) 1)) [1 2 3 5])))))
 
-(deftest test-1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad
+(deftest length_test_1
   (testing "returns the length of a vector -> empty vector"
     (is (= 0 (list-ops/length [])))))
 
-(deftest test-d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e
+(deftest length_test_2
   (testing "returns the length of a vector -> non-empty vector"
     (is (= 4 (list-ops/length [1 2 3 4])))))
 
-(deftest test-c0bc8962-30e2-4bec-9ae4-668b8ecd75aa
+(deftest apply-to-each_test_1
   (testing "return a vector of elements whose values equal the vector value transformed by the mapping function -> empty vector"
     (is (= [] (list-ops/apply-to-each (fn [x] (+ x 1)) [])))))
 
-(deftest test-11e71a95-e78b-4909-b8e4-60cdcaec0e91
+(deftest apply-to-each_test_2
   (testing "return a vector of elements whose values equal the vector value transformed by the mapping function -> non-empty vector"
     (is (= [2 4 6 8] (list-ops/apply-to-each (fn [x] (+ x 1)) [1 3 5 7])))))
 
-(deftest test-36549237-f765-4a4c-bfd9-5d3a8f7b07d2
+(deftest foldl_test_1
   (testing "folds (reduces) the given vector from the left with a function -> empty vector"
     (is (= 2 (list-ops/foldl (fn [acc el] (* el acc)) [] 2)))))
 
-(deftest test-7a626a3c-03ec-42bc-9840-53f280e13067
+(deftest foldl_test_2
   (testing "folds (reduces) the given vector from the left with a function -> direction independent function applied to non-empty vector"
     (is (= 15 (list-ops/foldl (fn [acc el] (+ el acc)) [1 2 3 4] 5)))))
 
-(deftest test-d7fcad99-e88e-40e1-a539-4c519681f390
+(deftest foldl_test_3
   (testing "folds (reduces) the given vector from the left with a function -> direction dependent function applied to non-empty vector"
     (is (= 64 (list-ops/foldl (fn [acc el] (/ el acc)) [1 2 3 4] 24)))))
 
-(deftest test-17214edb-20ba-42fc-bda8-000a5ab525b0
+(deftest foldr_test_1
   (testing "folds (reduces) the given vector from the right with a function -> empty vector"
     (is (= 2 (list-ops/foldr (fn [acc el] (* el acc)) [] 2)))))
 
-(deftest test-e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd
+(deftest foldr_test_2
   (testing "folds (reduces) the given vector from the right with a function -> direction independent function applied to non-empty vector"
     (is (= 15 (list-ops/foldr (fn [acc el] (+ el acc)) [1 2 3 4] 5)))))
 
-(deftest test-8066003b-f2ff-437e-9103-66e6df474844
+(deftest foldr_test_3
   (testing "folds (reduces) the given vector from the right with a function -> direction dependent function applied to non-empty vector"
     (is (= 9 (list-ops/foldr (fn [acc el] (/ el acc)) [1 2 3 4] 24)))))
 
-(deftest test-94231515-050e-4841-943d-d4488ab4ee30
+(deftest reverse-order_test_1
   (testing "reverse the elements of the vector -> empty vector"
     (is (= [] (list-ops/reverse-order [])))))
 
-(deftest test-fcc03d1e-42e0-4712-b689-d54ad761f360
+(deftest reverse-order_test_2
   (testing "reverse the elements of the vector -> non-empty vector"
     (is (= [7 5 3 1] (list-ops/reverse-order [1 3 5 7])))))
 
-(deftest test-40872990-b5b8-4cb8-9085-d91fc0d05d26
+(deftest reverse-order_test_3
   (testing "reverse the elements of the vector -> vector of vectors is not flattened"
     (is (= [[4 5 6] [] [3] [1 2]] (list-ops/reverse-order [[1 2] [3] [] [4 5 6]])))))

--- a/exercises/practice/minesweeper/test/minesweeper_test.clj
+++ b/exercises/practice/minesweeper/test/minesweeper_test.clj
@@ -8,13 +8,13 @@
   [coll]
   (clojure.string/join separator coll))
 
-(deftest test-650ac4c0-ad6b-4b41-acde-e4ea5852c3b8
+(deftest draw_test_1
   (testing "no columns"
     (is (= (join-with-line-separator [""])
            (minesweeper/draw
              (join-with-line-separator [""]))))))
 
-(deftest test-6fbf8f6d-a03b-42c9-9a58-b489e9235478
+(deftest draw_test_2
   (testing "no mines"
     (is (= (join-with-line-separator ["   "
                                       "   "
@@ -24,7 +24,7 @@
                                         "   "
                                         "   "]))))))
 
-(deftest test-61aff1c4-fb31-4078-acad-cd5f1e635655
+(deftest draw_test_3
   (testing "minefield with only mines"
     (is (= (join-with-line-separator ["***"
                                       "***"
@@ -34,7 +34,7 @@
                                         "***"
                                         "***"]))))))
 
-(deftest test-84167147-c504-4896-85d7-246b01dea7c5
+(deftest draw_test_4
   (testing "mine surrounded by spaces"
     (is (= (join-with-line-separator ["111"
                                       "1*1"
@@ -45,7 +45,7 @@
                                         "   "]))))))
 
 
-(deftest test-cb878f35-43e3-4c9d-93d9-139012cccc4a
+(deftest draw_test_5
   (testing "space surrounded by mines"
     (is (= (join-with-line-separator ["***"
                                       "*8*"
@@ -55,19 +55,19 @@
                                         "* *"
                                         "***"]))))))
 
-(deftest test-7037f483-ddb4-4b35-b005-0d0f4ef4606f
+(deftest draw_test_6
   (testing "horizontal line"
     (is (= (join-with-line-separator ["1*2*1"])
            (minesweeper/draw
              (join-with-line-separator [" * * "]))))))
 
-(deftest test-e359820f-bb8b-4eda-8762-47b64dba30a6
+(deftest draw_test_7
   (testing "horizontal line, mines at edges"
     (is (= (join-with-line-separator ["*1 1*"])
            (minesweeper/draw
              (join-with-line-separator ["*   *"]))))))
 
-(deftest test-c5198b50-804f-47e9-ae02-c3b42f7ce3ab
+(deftest draw_test_8
   (testing "vertical line"
     (is (= (join-with-line-separator ["1"
                                       "*"
@@ -81,7 +81,7 @@
                                         "*"
                                         " "]))))))
 
-(deftest test-0c79a64d-703d-4660-9e90-5adfa5408939
+(deftest draw_test_9
   (testing "vertical line, mines at edges"
     (is (= (join-with-line-separator ["*"
                                       "1"
@@ -95,7 +95,7 @@
                                         " "
                                         "*"]))))))
 
-(deftest test-4b098563-b7f3-401c-97c6-79dd1b708f34
+(deftest draw_test_10
   (testing "cross"
     (is (= (join-with-line-separator [" 2*2 "
                                       "25*52"
@@ -109,7 +109,7 @@
                                         "  *  "
                                         "  *  "]))))))
 
-(deftest test-04a260f1-b40a-4e89-839e-8dd8525abe0e
+(deftest draw_test_11
   (testing "large minefield"
     (is (= (join-with-line-separator ["1*22*1"
                                       "12*322"

--- a/exercises/practice/pythagorean-triplet/test/pythagorean_triplet_test.clj
+++ b/exercises/practice/pythagorean-triplet/test/pythagorean_triplet_test.clj
@@ -2,29 +2,29 @@
   (:require [clojure.test :refer [deftest testing is]]
             pythagorean-triplet))
 
-(deftest test-a19de65d-35b8-4480-b1af-371d9541e706
+(deftest find-pythagorean-triplets_test_1
   (testing "triplets whose sum is 12"
     (is (= [[3 4 5]] (pythagorean-triplet/find-pythagorean-triplets 12)))))
 
-(deftest test-48b21332-0a3d-43b2-9a52-90b2a6e5c9f5
+(deftest find-pythagorean-triplets_test_2
   (testing "triplets whose sum is 108"
     (is (= [[27 36 45]] (pythagorean-triplet/find-pythagorean-triplets 108)))))
 
-(deftest test-dffc1266-418e-4daa-81af-54c3e95c3bb5
+(deftest find-pythagorean-triplets_test_3
   (testing "triplets whose sum is 1000"
     (is (= [[200 375 425]] (pythagorean-triplet/find-pythagorean-triplets 1000)))))
 
-(deftest test-5f86a2d4-6383-4cce-93a5-e4489e79b186
+(deftest find-pythagorean-triplets_test_4
   (testing "no matching triplets for 1001"
     (is (= [] (pythagorean-triplet/find-pythagorean-triplets 1001)))))
 
-(deftest test-bf17ba80-1596-409a-bb13-343bdb3b2904
+(deftest find-pythagorean-triplets_test_5
   (testing "returns all matching triplets"
     (is (= [[9 40 41]
             [15 36 39]]
            (pythagorean-triplet/find-pythagorean-triplets 90)))))
 
-(deftest test-9d8fb5d5-6c6f-42df-9f95-d3165963ac57
+(deftest find-pythagorean-triplets_test_6
   (testing "several matching triplets"
     (is (= [[40 399 401]
             [56 390 394]
@@ -36,7 +36,7 @@
             [240 252 348]]
            (pythagorean-triplet/find-pythagorean-triplets 840)))))
 
-(deftest test-f5be5734-8aa0-4bd1-99a2-02adcc4402b4
+(deftest find-pythagorean-triplets_test_7
   (testing "triplets for large number"
     (is (= [[1200 14375 14425]
             [1875 14000 14125]

--- a/exercises/practice/spiral-matrix/test/spiral_matrix_test.clj
+++ b/exercises/practice/spiral-matrix/test/spiral_matrix_test.clj
@@ -2,30 +2,30 @@
   (:require [clojure.test :refer [deftest is testing]]
             spiral-matrix))
 
-(deftest test-8f584201-b446-4bc9-b132-811c8edd9040
+(deftest spiral_test_1
   (testing "empty spiral"
     (is (= []
            (spiral-matrix/spiral 0)))))
 
-(deftest test-e40ae5f3-e2c9-4639-8116-8a119d632ab2
+(deftest spiral_test_2
   (testing "trivial spiral"
     (is (= [[1]]
            (spiral-matrix/spiral 1)))))
 
-(deftest test-cf05e42d-eb78-4098-a36e-cdaf0991bc48
+(deftest spiral_test_3
   (testing "spiral of size 2"
     (is (= [[1 2]
             [4 3]]
            (spiral-matrix/spiral 2)))))
 
-(deftest test-1c475667-c896-4c23-82e2-e033929de939
+(deftest spiral_test_4
   (testing "spiral of size 3"
     (is (= [[1 2 3]
             [8 9 4]
             [7 6 5]]
            (spiral-matrix/spiral 3)))))
 
-(deftest test-05ccbc48-d891-44f5-9137-f4ce462a759d
+(deftest spiral_test_5
   (testing "spiral of size 4"
     (is (= [[1  2  3  4]
             [12 13 14 5]
@@ -33,7 +33,7 @@
             [10 9  8  7]]
            (spiral-matrix/spiral 4)))))
 
-(deftest test-f4d2165b-1738-4e0c-bed0-c459045ae50d
+(deftest spiral_test_6
   (testing "spiral of size 5"
     (is (= [[1  2  3  4  5]
             [16 17 18 19 6]

--- a/exercises/practice/spiral-matrix/test/spiral_matrix_test.clj
+++ b/exercises/practice/spiral-matrix/test/spiral_matrix_test.clj
@@ -3,30 +3,30 @@
             spiral-matrix))
 
 (deftest test-8f584201-b446-4bc9-b132-811c8edd9040
-  (testing "Empty spiral"
+  (testing "empty spiral"
     (is (= []
            (spiral-matrix/spiral 0)))))
 
 (deftest test-e40ae5f3-e2c9-4639-8116-8a119d632ab2
-  (testing "Trivial spiral"
+  (testing "trivial spiral"
     (is (= [[1]]
            (spiral-matrix/spiral 1)))))
 
 (deftest test-cf05e42d-eb78-4098-a36e-cdaf0991bc48
-  (testing "Spiral of size 2"
+  (testing "spiral of size 2"
     (is (= [[1 2]
             [4 3]]
            (spiral-matrix/spiral 2)))))
 
 (deftest test-1c475667-c896-4c23-82e2-e033929de939
-  (testing "Spiral of size 3"
+  (testing "spiral of size 3"
     (is (= [[1 2 3]
             [8 9 4]
             [7 6 5]]
            (spiral-matrix/spiral 3)))))
 
 (deftest test-05ccbc48-d891-44f5-9137-f4ce462a759d
-  (testing "Spiral of size 4"
+  (testing "spiral of size 4"
     (is (= [[1  2  3  4]
             [12 13 14 5]
             [11 16 15 6]
@@ -34,7 +34,7 @@
            (spiral-matrix/spiral 4)))))
 
 (deftest test-f4d2165b-1738-4e0c-bed0-c459045ae50d
-  (testing "Spiral of size 5"
+  (testing "spiral of size 5"
     (is (= [[1  2  3  4  5]
             [16 17 18 19 6]
             [15 24 25 20 7]

--- a/exercises/practice/spiral-matrix/test/spiral_matrix_test.clj
+++ b/exercises/practice/spiral-matrix/test/spiral_matrix_test.clj
@@ -1,5 +1,5 @@
 (ns spiral-matrix-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest testing is]]
             spiral-matrix))
 
 (deftest spiral_test_1

--- a/exercises/practice/sublist/test/sublist_test.clj
+++ b/exercises/practice/sublist/test/sublist_test.clj
@@ -1,5 +1,5 @@
 (ns sublist-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest testing is]]
             sublist))
 
 (deftest test-97319c93-ebc5-47ab-a022-02a1980e1d29

--- a/exercises/practice/sublist/test/sublist_test.clj
+++ b/exercises/practice/sublist/test/sublist_test.clj
@@ -3,73 +3,73 @@
             sublist))
 
 (deftest test-97319c93-ebc5-47ab-a022-02a1980e1d29
-  (testing "Empty lists"
+  (testing "empty lists"
     (is (= :equal (sublist/classify [] [])))))
 
 (deftest test-de27dbd4-df52-46fe-a336-30be58457382
-  (testing "Empty list within non empty list"
+  (testing "empty list within non empty list"
     (is (= :sublist (sublist/classify [] [1 2 3])))))
 
 (deftest test-5487cfd1-bc7d-429f-ac6f-1177b857d4fb
-  (testing "Non empty list contains empty list"
+  (testing "non empty list contains empty list"
     (is (= :superlist (sublist/classify [1 2 3] [])))))
 
 (deftest test-1f390b47-f6b2-4a93-bc23-858ba5dda9a6
-  (testing "List equals itself"
+  (testing "list equals itself"
     (is (= :equal (sublist/classify [1 2 3] [1 2 3])))))
 
 (deftest test-7ed2bfb2-922b-4363-ae75-f3a05e8274f5
-  (testing "Different lists"
+  (testing "different lists"
     (is (= :unequal (sublist/classify [1 2 3] [2 3 4])))))
 
 (deftest test-3b8a2568-6144-4f06-b0a1-9d266b365341
-  (testing "False start"
+  (testing "false start"
     (is (= :sublist (sublist/classify [1 2 5] [0 1 2 3 1 2 5 6])))))
 
 (deftest test-dc39ed58-6311-4814-be30-05a64bc8d9b1
-  (testing "Consecutive"
+  (testing "consecutive"
     (is (= :sublist (sublist/classify [1 1 2] [0 1 1 1 2 1 2])))))
 
 (deftest test-d1270dab-a1ce-41aa-b29d-b3257241ac26
-  (testing "Sublist at start"
+  (testing "sublist at start"
     (is (= :sublist (sublist/classify [0 1 2] [0 1 2 3 4 5])))))
 
 (deftest test-81f3d3f7-4f25-4ada-bcdc-897c403de1b6
-  (testing "Sublist in middle"
+  (testing "sublist in middle"
     (is (= :sublist (sublist/classify [2 3 4] [0 1 2 3 4 5])))))
 
 (deftest test-43bcae1e-a9cf-470e-923e-0946e04d8fdd
-  (testing "Sublist at end"
+  (testing "sublist at end"
     (is (= :sublist (sublist/classify [3 4 5] [0 1 2 3 4 5])))))
 
 (deftest test-76cf99ed-0ff0-4b00-94af-4dfb43fe5caa
-  (testing "At start of superlist"
+  (testing "at start of superlist"
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [0 1 2])))))
 
 (deftest test-b83989ec-8bdf-4655-95aa-9f38f3e357fd
-  (testing "In middle of superlist"
+  (testing "in middle of superlist"
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [2 3])))))
 
 (deftest test-26f9f7c3-6cf6-4610-984a-662f71f8689b
-  (testing "At end of superlist"
+  (testing "at end of superlist"
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [3 4 5])))))
 
 (deftest test-0a6db763-3588-416a-8f47-76b1cedde31e
-  (testing "First list missing element from second list"
+  (testing "first list missing element from second list"
     (is (= :unequal (sublist/classify [1 3] [1 2 3])))))
 
 (deftest test-83ffe6d8-a445-4a3c-8795-1e51a95e65c3
-  (testing "Second list missing element from first list"
+  (testing "second list missing element from first list"
     (is (= :unequal (sublist/classify [1 2 3] [1 3])))))
 
 (deftest test-7bc76cb8-5003-49ca-bc47-cdfbe6c2bb89
-  (testing "First list missing additional digits from second list"
+  (testing "first list missing additional digits from second list"
     (is (= :unequal (sublist/classify [1 2] [1 22])))))
 
 (deftest test-0d7ee7c1-0347-45c8-9ef5-b88db152b30b
-  (testing "Order matters to a list"
+  (testing "order matters to a list"
     (is (= :unequal (sublist/classify [1 2 3] [3 2 1])))))
 
 (deftest test-5f47ce86-944e-40f9-9f31-6368aad70aa6
-  (testing "Same digits but different numbers"
+  (testing "same digits but different numbers"
     (is (= :unequal (sublist/classify [1 0 1] [10 1])))))

--- a/exercises/practice/sublist/test/sublist_test.clj
+++ b/exercises/practice/sublist/test/sublist_test.clj
@@ -2,74 +2,74 @@
   (:require [clojure.test :refer [deftest testing is]]
             sublist))
 
-(deftest test-97319c93-ebc5-47ab-a022-02a1980e1d29
+(deftest classify_test_1
   (testing "empty lists"
     (is (= :equal (sublist/classify [] [])))))
 
-(deftest test-de27dbd4-df52-46fe-a336-30be58457382
+(deftest classify_test_2
   (testing "empty list within non empty list"
     (is (= :sublist (sublist/classify [] [1 2 3])))))
 
-(deftest test-5487cfd1-bc7d-429f-ac6f-1177b857d4fb
+(deftest classify_test_3
   (testing "non empty list contains empty list"
     (is (= :superlist (sublist/classify [1 2 3] [])))))
 
-(deftest test-1f390b47-f6b2-4a93-bc23-858ba5dda9a6
+(deftest classify_test_4
   (testing "list equals itself"
     (is (= :equal (sublist/classify [1 2 3] [1 2 3])))))
 
-(deftest test-7ed2bfb2-922b-4363-ae75-f3a05e8274f5
+(deftest classify_test_5
   (testing "different lists"
     (is (= :unequal (sublist/classify [1 2 3] [2 3 4])))))
 
-(deftest test-3b8a2568-6144-4f06-b0a1-9d266b365341
+(deftest classify_test_6
   (testing "false start"
     (is (= :sublist (sublist/classify [1 2 5] [0 1 2 3 1 2 5 6])))))
 
-(deftest test-dc39ed58-6311-4814-be30-05a64bc8d9b1
+(deftest classify_test_7
   (testing "consecutive"
     (is (= :sublist (sublist/classify [1 1 2] [0 1 1 1 2 1 2])))))
 
-(deftest test-d1270dab-a1ce-41aa-b29d-b3257241ac26
+(deftest classify_test_8
   (testing "sublist at start"
     (is (= :sublist (sublist/classify [0 1 2] [0 1 2 3 4 5])))))
 
-(deftest test-81f3d3f7-4f25-4ada-bcdc-897c403de1b6
+(deftest classify_test_9
   (testing "sublist in middle"
     (is (= :sublist (sublist/classify [2 3 4] [0 1 2 3 4 5])))))
 
-(deftest test-43bcae1e-a9cf-470e-923e-0946e04d8fdd
+(deftest classify_test_10
   (testing "sublist at end"
     (is (= :sublist (sublist/classify [3 4 5] [0 1 2 3 4 5])))))
 
-(deftest test-76cf99ed-0ff0-4b00-94af-4dfb43fe5caa
+(deftest classify_test_11
   (testing "at start of superlist"
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [0 1 2])))))
 
-(deftest test-b83989ec-8bdf-4655-95aa-9f38f3e357fd
+(deftest classify_test_12
   (testing "in middle of superlist"
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [2 3])))))
 
-(deftest test-26f9f7c3-6cf6-4610-984a-662f71f8689b
+(deftest classify_test_13
   (testing "at end of superlist"
     (is (= :superlist (sublist/classify [0 1 2 3 4 5] [3 4 5])))))
 
-(deftest test-0a6db763-3588-416a-8f47-76b1cedde31e
+(deftest classify_test_14
   (testing "first list missing element from second list"
     (is (= :unequal (sublist/classify [1 3] [1 2 3])))))
 
-(deftest test-83ffe6d8-a445-4a3c-8795-1e51a95e65c3
+(deftest classify_test_15
   (testing "second list missing element from first list"
     (is (= :unequal (sublist/classify [1 2 3] [1 3])))))
 
-(deftest test-7bc76cb8-5003-49ca-bc47-cdfbe6c2bb89
+(deftest classify_test_16
   (testing "first list missing additional digits from second list"
     (is (= :unequal (sublist/classify [1 2] [1 22])))))
 
-(deftest test-0d7ee7c1-0347-45c8-9ef5-b88db152b30b
+(deftest classify_test_17
   (testing "order matters to a list"
     (is (= :unequal (sublist/classify [1 2 3] [3 2 1])))))
 
-(deftest test-5f47ce86-944e-40f9-9f31-6368aad70aa6
+(deftest classify_test_18
   (testing "same digits but different numbers"
     (is (= :unequal (sublist/classify [1 0 1] [10 1])))))

--- a/exercises/practice/word-count/test/word_count_test.clj
+++ b/exercises/practice/word-count/test/word_count_test.clj
@@ -2,19 +2,19 @@
   (:require [clojure.test :refer [deftest testing is]]
             word-count))
 
-(deftest test-61559d5f-2cad-48fb-af53-d3973a9ee9ef
+(deftest word-count_test_1
   (testing "count one word"
     (is (= {"word" 1}
            (word-count/word-count "word")))))
 
-(deftest test-5abd53a3-1aed-43a4-a15a-29f88c09cbbd
+(deftest word-count_test_2
   (testing "count one of each word"
     (is (= {"one" 1
             "of" 1
             "each" 1}
            (word-count/word-count "one of each")))))
 
-(deftest test-2a3091e5-952e-4099-9fac-8f85d9655c0e
+(deftest word-count_test_3
   (testing "multiple occurrences of a word"
     (is (= {"one" 1
             "fish" 4
@@ -23,21 +23,21 @@
             "blue" 1}
            (word-count/word-count "one fish two fish red fish blue fish")))))
 
-(deftest test-e81877ae-d4da-4af4-931c-d923cd621ca6
+(deftest word-count_test_4
   (testing "handles cramped lists"
     (is (= {"one" 1
             "two" 1
             "three" 1}
            (word-count/word-count "one,two,three")))))
 
-(deftest test-7349f682-9707-47c0-a9af-be56e1e7ff30
+(deftest word-count_test_5
   (testing "handles expanded lists"
     (is (= {"one" 1
             "two" 1
             "three" 1}
            (word-count/word-count "one,\ntwo,\nthree")))))
 
-(deftest test-a514a0f2-8589-4279-8892-887f76a14c82
+(deftest word-count_test_6
   (testing "ignore punctuation"
     (is (= {"car" 1
             "carpet" 1
@@ -46,20 +46,20 @@
             "javascript" 1}
            (word-count/word-count "car: carpet as java: javascript!!&@$%^&")))))
 
-(deftest test-d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e
+(deftest word-count_test_7
   (testing "include numbers"
     (is (= {"testing" 2
             "1" 1
             "2" 1}
            (word-count/word-count "testing, 1, 2 testing")))))
 
-(deftest test-dac6bc6a-21ae-4954-945d-d7f716392dbf
+(deftest word-count_test_8
   (testing "normalize case"
     (is (= {"go" 3
             "stop" 2}
            (word-count/word-count "go Go GO Stop stop")))))
 
-(deftest test-4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3
+(deftest word-count_test_9
   (testing "with apostrophes"
     (is (= {"first" 1
             "don't" 2
@@ -71,7 +71,7 @@
             "it" 1}
            (word-count/word-count "'First: don't laugh. Then: don't cry. You're getting it.'")))))
 
-(deftest test-be72af2b-8afe-4337-b151-b297202e4a7b
+(deftest word-count_test_10
   (testing "with quotations"
     (is (= {"joe" 1
             "can't" 1
@@ -81,7 +81,7 @@
             "and" 1}
            (word-count/word-count "Joe can't tell between 'large' and large.")))))
 
-(deftest test-8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6
+(deftest word-count_test_11
   (testing "substrings from the beginning"
     (is (= {"joe" 1
             "can't" 1
@@ -93,20 +93,20 @@
             "a" 1}
            (word-count/word-count "Joe can't tell between app, apple and a.")))))
 
-(deftest test-c5f4ef26-f3f7-4725-b314-855c04fb4c13
+(deftest word-count_test_12
   (testing "multiple spaces not detected as a word"
     (is (= {"multiple" 1
             "whitespaces" 1}
            (word-count/word-count " multiple   whitespaces")))))
 
-(deftest test-50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360
+(deftest word-count_test_13
   (testing "alternating word separators not detected as a word"
     (is (= {"one" 1
             "two" 1
             "three" 1}
            (word-count/word-count ",\n,one,\n ,two \n 'three'")))))
 
-(deftest test-6d00f1db-901c-4bec-9829-d20eb3044557
+(deftest word-count_test_14
   (testing "quotation for word with apostrophe"
     (is (= {"can" 1
             "can't" 2}


### PR DESCRIPTION
No more uuids in test functions (removed only from already merged PRs)

Also test descriptions in Clojure tests are now identical to the descriptions in their corresponding .toml files.