### PR TITLE
atbash-cipher: Sync tests with problem specifications

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -10,7 +10,8 @@
     "kytrinyx",
     "mathias",
     "sjwarner-bp",
-    "yurrriq"
+    "yurrriq",
+    "tasxatzial"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/atbash-cipher/.meta/example.clj
+++ b/exercises/practice/atbash-cipher/.meta/example.clj
@@ -1,5 +1,6 @@
 (ns atbash-cipher
-  (:require [clojure.string :as str]))
+  (:require [clojure.set]
+            [clojure.string :as str]))
 
 (def ^:private letters
   (map char
@@ -9,13 +10,24 @@
   (apply hash-map
          (interleave letters (reverse letters))))
 
+(def ^:private from-cipher
+  (clojure.set/map-invert to-cipher))
+
 (defn- sanitize
   [plaintext]
   (str/replace (str/lower-case plaintext) #"\W" ""))
 
-(defn- cipher
+(defn- remove-spaces
+  [ciphertext]
+  (str/replace ciphertext #" " ""))
+
+(defn- cipher-char
   [plain-char]
   (or (to-cipher plain-char) plain-char))
+
+(defn- plain-char
+  [cipher-char]
+  (or (from-cipher cipher-char) cipher-char))
 
 (defn- to-chunks
   [character-list]
@@ -25,6 +37,13 @@
   [plaintext]
   (->> plaintext
        sanitize
-       (map cipher)
+       (map cipher-char)
        to-chunks
        (str/join " ")))
+
+(defn decode
+  [ciphertext]
+  (->> ciphertext
+       remove-spaces
+       (map plain-char)
+       (apply str)))

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,45 +1,52 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
-description = "encode yes"
+description = "encode -> encode yes"
 
 [b4ffe781-ea81-4b74-b268-cc58ba21c739]
-description = "encode no"
+description = "encode -> encode no"
 
 [10e48927-24ab-4c4d-9d3f-3067724ace00]
-description = "encode OMG"
+description = "encode -> encode OMG"
 
 [d59b8bc3-509a-4a9a-834c-6f501b98750b]
-description = "encode spaces"
+description = "encode -> encode spaces"
 
 [31d44b11-81b7-4a94-8b43-4af6a2449429]
-description = "encode mindblowingly"
+description = "encode -> encode mindblowingly"
 
 [d503361a-1433-48c0-aae0-d41b5baa33ff]
-description = "encode numbers"
+description = "encode -> encode numbers"
 
 [79c8a2d5-0772-42d4-b41b-531d0b5da926]
-description = "encode deep thought"
+description = "encode -> encode deep thought"
 
 [9ca13d23-d32a-4967-a1fd-6100b8742bab]
-description = "encode all the letters"
+description = "encode -> encode all the letters"
 
 [bb50e087-7fdf-48e7-9223-284fe7e69851]
-description = "decode exercism"
+description = "decode -> decode exercism"
 
 [ac021097-cd5d-4717-8907-b0814b9e292c]
-description = "decode a sentence"
+description = "decode -> decode a sentence"
 
 [18729de3-de74-49b8-b68c-025eaf77f851]
-description = "decode numbers"
+description = "decode -> decode numbers"
 
 [0f30325f-f53b-415d-ad3e-a7a4f63de034]
-description = "decode all the letters"
+description = "decode -> decode all the letters"
 
 [39640287-30c6-4c8c-9bac-9d613d1a5674]
-description = "decode with too many spaces"
+description = "decode -> decode with too many spaces"
 
 [b34edf13-34c0-49b5-aa21-0768928000d5]
-description = "decode with no spaces"
+description = "decode -> decode with no spaces"

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -47,6 +47,8 @@ description = "decode -> decode all the letters"
 
 [39640287-30c6-4c8c-9bac-9d613d1a5674]
 description = "decode -> decode with too many spaces"
+include = false
 
 [b34edf13-34c0-49b5-aa21-0768928000d5]
 description = "decode -> decode with no spaces"
+include = false

--- a/exercises/practice/atbash-cipher/src/atbash_cipher.clj
+++ b/exercises/practice/atbash-cipher/src/atbash_cipher.clj
@@ -1,5 +1,11 @@
 (ns atbash-cipher)
 
-(defn encode [] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn encode
+  [s]
+  ;; function body
+  )
+
+(defn decode
+  [s]
+  ;; function body
+  )

--- a/exercises/practice/atbash-cipher/test/atbash_cipher_test.clj
+++ b/exercises/practice/atbash-cipher/test/atbash_cipher_test.clj
@@ -61,13 +61,3 @@
   (testing "decode -> decode all the letters"
     (is (= "thequickbrownfoxjumpsoverthelazydog"
            (atbash-cipher/decode "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt")))))
-
-(deftest decode_test_5
-  (testing "decode -> decode with too many spaces"
-    (is (= "exercism"
-           (atbash-cipher/decode "vc vix    r hn")))))
-
-(deftest decode_test_6
-  (testing "decode -> decode with no spaces"
-    (is (= "anobstacleisoftenasteppingstone"
-           (atbash-cipher/decode "zmlyhgzxovrhlugvmzhgvkkrmthglmv")))))

--- a/exercises/practice/atbash-cipher/test/atbash_cipher_test.clj
+++ b/exercises/practice/atbash-cipher/test/atbash_cipher_test.clj
@@ -1,30 +1,73 @@
 (ns atbash-cipher-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest testing is]]
             atbash-cipher))
 
-(deftest encode-no
-  (is (= "ml" (atbash-cipher/encode "no"))))
+(deftest encode_test_1
+  (testing "encode -> encode yes"
+    (is (= "bvh"
+           (atbash-cipher/encode "yes")))))
 
-(deftest encode-yes
-  (is (= "bvh" (atbash-cipher/encode "yes"))))
+(deftest encode_test_2
+  (testing "encode -> encode no"
+    (is (= "ml"
+           (atbash-cipher/encode "no")))))
 
-(deftest encode-OMG
-  (is (= "lnt" (atbash-cipher/encode "OMG"))))
+(deftest encode_test_3
+  (testing "encode -> encode OMG"
+    (is (= "lnt"
+           (atbash-cipher/encode "OMG")))))
 
-(deftest encode-O-M-G
-  (is (= "lnt" (atbash-cipher/encode "O M G"))))
+(deftest encode_test_4
+  (testing "encode -> encode spaces"
+    (is (= "lnt"
+           (atbash-cipher/encode "O M G")))))
 
-(deftest encode-long-word
-  (is (= "nrmwy oldrm tob" (atbash-cipher/encode "mindblowingly"))))
+(deftest encode_test_5
+  (testing "encode -> encode mindblowingly"
+    (is (= "nrmwy oldrm tob"
+           (atbash-cipher/encode "mindblowingly")))))
 
-(deftest encode-numbers
-  (is (= "gvhgr mt123 gvhgr mt"
-         (atbash-cipher/encode "Testing, 1 2 3, testing."))))
+(deftest encode_test_6
+  (testing "encode -> encode numbers"
+    (is (= "gvhgr mt123 gvhgr mt"
+           (atbash-cipher/encode "Testing, 1 2 3, testing.")))))
 
-(deftest encode-sentence
-  (is (= "gifgs rhurx grlm" (atbash-cipher/encode "Truth is fiction."))))
+(deftest encode_test_7
+  (testing "encode -> encode deep thought"
+    (is (= "gifgs rhurx grlm"
+           (atbash-cipher/encode "Truth is fiction.")))))
 
-(deftest encode-all-the-things
-  (let [plaintext "The quick brown fox jumps over the lazy dog."
-        cipher    "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"]
-    (is (= cipher (atbash-cipher/encode plaintext)))))
+(deftest encode_test_8
+  (testing "encode -> encode all the letters"
+    (is (= "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+           (atbash-cipher/encode "The quick brown fox jumps over the lazy dog.")))))
+
+(deftest decode_test_1
+  (testing "decode -> decode exercism"
+    (is (= "exercism"
+           (atbash-cipher/decode "vcvix rhn")))))
+
+(deftest decode_test_2
+  (testing "decode -> decode a sentence"
+    (is (= "anobstacleisoftenasteppingstone"
+           (atbash-cipher/decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v")))))
+
+(deftest decode_test_3
+  (testing "decode -> decode numbers"
+    (is (= "testing123testing"
+           (atbash-cipher/decode "gvhgr mt123 gvhgr mt")))))
+
+(deftest decode_test_4
+  (testing "decode -> decode all the letters"
+    (is (= "thequickbrownfoxjumpsoverthelazydog"
+           (atbash-cipher/decode "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt")))))
+
+(deftest decode_test_5
+  (testing "decode -> decode with too many spaces"
+    (is (= "exercism"
+           (atbash-cipher/decode "vc vix    r hn")))))
+
+(deftest decode_test_6
+  (testing "decode -> decode with no spaces"
+    (is (= "anobstacleisoftenasteppingstone"
+           (atbash-cipher/decode "zmlyhgzxovrhlugvmzhgvkkrmthglmv")))))


### PR DESCRIPTION
Last two decode tests have been marked as not implemented because the inputs are not valid encoded strings. They should be removed from the specs as well.

https://forum.exercism.org/t/atbash-cipher-are-the-last-two-tests-invalid/13482

Also, this update will invalidate all solutions, as the old tests did not even include the decoding part of the exercise.