### PR TITLE
Fix warning about slf4j not being available

### DIFF
--- a/generators/deps.edn
+++ b/generators/deps.edn
@@ -2,4 +2,5 @@
  :deps {org.clojure/data.json {:mvn/version "2.5.1"}
         hbs/hbs {:mvn/version "1.0.3"}
         io.github.tonsky/toml-clj {:mvn/version "0.1.0"}
-        clj-jgit/clj-jgit {:mvn/version "1.1.0"}}}
+        clj-jgit/clj-jgit {:mvn/version "1.1.0"}
+        org.slf4j/slf4j-nop {:mvn/version "1.7.30"}}}


### PR DESCRIPTION
This must be caused by a dependency using this library