### PR TITLE
Simplify templates

### DIFF
--- a/exercises/practice/acronym/.meta/generator.tpl
+++ b/exercises/practice/acronym/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns acronym-test
   (:require [clojure.test :refer [deftest testing is]]
             acronym))
+
 {{#test_cases.abbreviate}}
 (deftest acronym_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (acronym/acronym {{input.phrase}})))))
-{{/test_cases.abbreviate~}}
+{{/test_cases.abbreviate}}

--- a/exercises/practice/anagram/.meta/generator.tpl
+++ b/exercises/practice/anagram/.meta/generator.tpl
@@ -1,9 +1,10 @@
 (ns anagram-test
   (:require [clojure.test :refer [deftest testing is]]
             anagram))
+
 {{#test_cases.findAnagrams}}
 (deftest anagrams-for_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}}
            (anagram/anagrams-for {{input.subject}} {{input.candidates}})))))
-{{/test_cases.findAnagrams~}}
+{{/test_cases.findAnagrams}}

--- a/exercises/practice/armstrong-numbers/.meta/generator.tpl
+++ b/exercises/practice/armstrong-numbers/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns armstrong-numbers-test
   (:require [clojure.test :refer [deftest testing is]]
             armstrong-numbers))
+
 {{#test_cases.isArmstrongNumber}}
 (deftest armstrong?_test_{{idx}}
   (testing {{description}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (armstrong-numbers/armstrong? {{input.number}})))))
-{{/test_cases.isArmstrongNumber~}}
+{{/test_cases.isArmstrongNumber}}

--- a/exercises/practice/change/.meta/generator.tpl
+++ b/exercises/practice/change/.meta/generator.tpl
@@ -1,6 +1,7 @@
 (ns change-test
   (:require [clojure.test :refer [deftest testing is]]
             change))
+
 {{#test_cases.findFewestCoins}}
 (deftest issue_test_{{idx}}
   (testing {{description}}
@@ -11,4 +12,4 @@
     (is (= {{expected}}
            (change/issue {{input.target}} {{input.coins}})))))
     {{/if~}}
-{{/test_cases.findFewestCoins~}}
+{{/test_cases.findFewestCoins}}

--- a/exercises/practice/darts/.meta/generator.tpl
+++ b/exercises/practice/darts/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns darts-test
   (:require [clojure.test :refer [deftest testing is]]
             darts))
+
 {{#test_cases.score}}
 (deftest score_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (darts/score {{input.x}} {{input.y}})))))
-{{/test_cases.score~}}
+{{/test_cases.score}}

--- a/exercises/practice/difference-of-squares/.meta/generator.tpl
+++ b/exercises/practice/difference-of-squares/.meta/generator.tpl
@@ -1,18 +1,21 @@
 (ns difference-of-squares-test
   (:require [clojure.test :refer [deftest testing is]]
             difference-of-squares))
+
 {{#test_cases.squareOfSum}}
 (deftest square-of-sum_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (difference-of-squares/square-of-sum {{input.number}})))))
-{{/test_cases.squareOfSum~}}
+{{/test_cases.squareOfSum}}
+
 {{#test_cases.sumOfSquares}}
 (deftest sum-of-squares_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (difference-of-squares/sum-of-squares {{input.number}})))))
-{{/test_cases.sumOfSquares~}}
+{{/test_cases.sumOfSquares}}
+
 {{#test_cases.differenceOfSquares}}
 (deftest difference_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (difference-of-squares/difference {{input.number}})))))
-{{/test_cases.differenceOfSquares~}}
+{{/test_cases.differenceOfSquares}}

--- a/exercises/practice/high-scores/.meta/generator.tpl
+++ b/exercises/practice/high-scores/.meta/generator.tpl
@@ -1,23 +1,27 @@
 (ns high-scores-test
   (:require [clojure.test :refer [deftest testing is]]
             high-scores))
+
 {{#test_cases.scores}}
 (deftest scores_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (high-scores/scores {{input.scores}})))))
-{{/test_cases.scores~}}
+{{/test_cases.scores}}
+
 {{#test_cases.latest}}
 (deftest latest_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (high-scores/latest {{input.scores}})))))
-{{/test_cases.latest~}}
+{{/test_cases.latest}}
+
 {{#test_cases.personalBest}}
 (deftest personal-best_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (high-scores/personal-best {{input.scores}})))))
-{{/test_cases.personalBest~}}
+{{/test_cases.personalBest}}
+
 {{#test_cases.personalTopThree}}
 (deftest personal-top-three_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (high-scores/personal-top-three {{input.scores}})))))
-{{/test_cases.personalTopThree~}}
+{{/test_cases.personalTopThree}}

--- a/exercises/practice/isbn-verifier/.meta/generator.tpl
+++ b/exercises/practice/isbn-verifier/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns isbn-verifier-test
   (:require [clojure.test :refer [deftest testing is]]
             isbn-verifier))
+
 {{#test_cases.isValid}}
 (deftest isbn?_test_{{idx}}
   (testing {{description}}
-    (is ({{#expected~}}true?{{else}}false?{{/expected}} (isbn-verifier/isbn? {{input.isbn}})))))
-{{/test_cases.isValid~}}
+    (is ({{#expected}}true?{{else}}false?{{/expected}} (isbn-verifier/isbn? {{input.isbn}})))))
+{{/test_cases.isValid}}

--- a/exercises/practice/isogram/.meta/generator.tpl
+++ b/exercises/practice/isogram/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns isogram-test
   (:require [clojure.test :refer [deftest testing is]]
             isogram))
+
 {{#test_cases.isIsogram}}
 (deftest isogram?_test_{{idx}}
   (testing {{description}}
-    (is ({{#expected~}}true?{{else}}false?{{/expected}} (isogram/isogram? {{input.phrase}})))))
-{{/test_cases.isIsogram~}}
+    (is ({{#expected}}true?{{else}}false?{{/expected}} (isogram/isogram? {{input.phrase}})))))
+{{/test_cases.isIsogram}}

--- a/exercises/practice/largest-series-product/.meta/generator.tpl
+++ b/exercises/practice/largest-series-product/.meta/generator.tpl
@@ -1,6 +1,7 @@
 (ns largest-series-product-test
   (:require [clojure.test :refer [deftest testing is]]
             largest-series-product))
+
 {{#test_cases.largestProduct}}
 (deftest largest-product_test_{{idx}}
   (testing {{description}}
@@ -9,4 +10,4 @@
     {{else}}
     (is (= {{expected}} (largest-series-product/largest-product {{input.span}} {{input.digits}})))))
     {{/if~}}
-{{/test_cases.largestProduct~}}
+{{/test_cases.largestProduct}}

--- a/exercises/practice/leap/.meta/generator.tpl
+++ b/exercises/practice/leap/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns leap-test
   (:require [clojure.test :refer [deftest testing is]]
             leap))
+
 {{#test_cases.leapYear}}
 (deftest leap-year?_test_{{idx}}
   (testing {{description}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (leap/leap-year? {{input.year}})))))
-{{/test_cases.leapYear~}}
+{{/test_cases.leapYear}}

--- a/exercises/practice/matrix/.meta/generator.tpl
+++ b/exercises/practice/matrix/.meta/generator.tpl
@@ -1,13 +1,15 @@
 (ns matrix-test
   (:require [clojure.test :refer [deftest testing is]]
             matrix))
+
 {{#test_cases.row}}
 (deftest get-row_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (matrix/get-row {{input.string}} {{input.index}})))))
-{{/test_cases.row~}}
+{{/test_cases.row}}
+
 {{#test_cases.column}}
 (deftest get-column_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (matrix/get-column {{input.string}} {{input.index}})))))
-{{/test_cases.column~}}
+{{/test_cases.column}}

--- a/exercises/practice/pangram/.meta/generator.tpl
+++ b/exercises/practice/pangram/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns pangram-test
   (:require [clojure.test :refer [deftest testing is]]
             pangram))
+
 {{#test_cases.isPangram}}
 (deftest pangram?_test_{{idx}}
   (testing {{description}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (pangram/pangram? {{input.sentence}})))))
-{{/test_cases.isPangram~}}
+{{/test_cases.isPangram}}

--- a/exercises/practice/pig-latin/.meta/generator.tpl
+++ b/exercises/practice/pig-latin/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns pig-latin-test
   (:require [clojure.test :refer [deftest testing is]]
             pig-latin))
+
 {{#test_cases.translate}}
 (deftest translate_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (pig-latin/translate {{input.phrase}})))))
-{{/test_cases.translate~}}
+{{/test_cases.translate}}

--- a/exercises/practice/resistor-color-duo/.meta/generator.tpl
+++ b/exercises/practice/resistor-color-duo/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns resistor-color-duo-test
   (:require [clojure.test :refer [deftest testing is]]
             resistor-color-duo))
+
 {{#test_cases.value}}
 (deftest resistor-value_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (resistor-color-duo/resistor-value {{input.colors}})))))
-{{/test_cases.value~}}
+{{/test_cases.value}}

--- a/exercises/practice/resistor-color/.meta/generator.tpl
+++ b/exercises/practice/resistor-color/.meta/generator.tpl
@@ -1,14 +1,16 @@
 (ns resistor-color-test
   (:require [clojure.test :refer [deftest testing is]]
             resistor-color))
+
 {{#test_cases.colors}}
 (deftest colors_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}}
            resistor-color/colors))))
-{{/test_cases.colors~}}
+{{/test_cases.colors}}
+
 {{#test_cases.colorCode}}
 (deftest color-code_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (resistor-color/color-code {{input.color}})))))
-{{/test_cases.colorCode~}}
+{{/test_cases.colorCode}}

--- a/exercises/practice/reverse-string/.meta/generator.tpl
+++ b/exercises/practice/reverse-string/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns reverse-string-test
   (:require [clojure.test :refer [deftest testing is]]
             reverse-string))
+
 {{#test_cases.reverse}}
 (deftest reverse-string_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (reverse-string/reverse-string {{input.value}})))))
-{{/test_cases.reverse~}}
+{{/test_cases.reverse}}

--- a/exercises/practice/roman-numerals/.meta/generator.tpl
+++ b/exercises/practice/roman-numerals/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns roman-numerals-test
   (:require [clojure.test :refer [deftest testing is]]
             roman-numerals))
+
 {{#test_cases.roman}}
 (deftest numerals_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (roman-numerals/numerals {{input.number}})))))
-{{/test_cases.roman~}}
+{{/test_cases.roman}}

--- a/exercises/practice/saddle-points/.meta/generator.tpl
+++ b/exercises/practice/saddle-points/.meta/generator.tpl
@@ -1,13 +1,13 @@
 (ns saddle-points-test
   (:require [clojure.test :refer [deftest testing is]]
             saddle-points))
+
 {{#test_cases.saddlePoints}}
 (deftest saddle-points_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}}
            (saddle-points/saddle-points
-             [{{~#input.matrix}}
+             [{{#input.matrix}}
               {{.}}
-              {{~/input.matrix}}
-             ])))))
-{{/test_cases.saddlePoints~}}
+              {{~/input.matrix}}])))))
+{{/test_cases.saddlePoints}}

--- a/exercises/practice/scrabble-score/.meta/generator.tpl
+++ b/exercises/practice/scrabble-score/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns scrabble-score-test
   (:require [clojure.test :refer [deftest testing is]]
             scrabble-score))
+
 {{#test_cases.score}}
 (deftest score-word_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (scrabble-score/score-word {{input.word}})))))
-{{/test_cases.score~}}
+{{/test_cases.score}}

--- a/exercises/practice/simple-cipher/.meta/generator.tpl
+++ b/exercises/practice/simple-cipher/.meta/generator.tpl
@@ -1,11 +1,13 @@
 (ns simple-cipher-test
   (:require [clojure.test :refer [deftest testing is]]
             simple-cipher))
+
 {{#test_cases.key}}
 (deftest rand-key_test_{{idx}}
   (testing {{description}}
     (is (true? (boolean (re-matches #{{expected.match}} (simple-cipher/rand-key)))))))
-{{/test_cases.key~}}
+{{/test_cases.key}}
+
 {{#test_cases.encode}}
 (deftest encode_test_{{idx}}
   (testing {{description}}
@@ -15,7 +17,8 @@
     (let [key (simple-cipher/rand-key)]
       (is (= (subs key 0 (count {{input.plaintext}})) (simple-cipher/encode key {{input.plaintext}}))))))    
     {{/if~}}
-{{/test_cases.encode~}}
+{{/test_cases.encode}}
+
 {{#test_cases.decode}}
 (deftest decode_test_{{idx}}
   (testing {{description}}
@@ -25,4 +28,4 @@
     (let [key (simple-cipher/rand-key)]
       (is (= {{expected}} (simple-cipher/decode key {{#if input.plaintext}}(simple-cipher/encode key {{input.plaintext}}{{else}}(subs key 0 (count {{expected}})){{/if}})))))
     {{/if~}}
-{{/test_cases.decode~}}
+{{/test_cases.decode}}

--- a/exercises/practice/square-root/.meta/generator.tpl
+++ b/exercises/practice/square-root/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns square-root-test
   (:require [clojure.test :refer [deftest testing is]]
             square-root))
+
 {{#test_cases.squareRoot}}
 (deftest square-root_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (square-root/square-root {{input.radicand}})))))
-{{/test_cases.squareRoot~}}
+{{/test_cases.squareRoot}}

--- a/exercises/practice/sum-of-multiples/.meta/generator.tpl
+++ b/exercises/practice/sum-of-multiples/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns sum-of-multiples-test
   (:require [clojure.test :refer [deftest testing is]]
             sum-of-multiples))
+
 {{#test_cases.sum}}
 (deftest sum-of-multiples_test_{{idx}}
   (testing {{description}}
     (is ({{#ifzero expected}}zero?{{else}}= {{expected}}{{/ifzero}} (sum-of-multiples/sum-of-multiples {{input.factors}} {{input.limit}})))))
-{{/test_cases.sum~}}
+{{/test_cases.sum}}

--- a/exercises/practice/triangle/.meta/generator.tpl
+++ b/exercises/practice/triangle/.meta/generator.tpl
@@ -1,18 +1,21 @@
 (ns triangle-test
   (:require [clojure.test :refer [deftest testing is]]
             triangle))
+
 {{#test_cases.equilateral}}
 (deftest equilateral?_test_{{idx}}
   (testing {{description}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (triangle/equilateral? {{input.sides.0}} {{input.sides.1}} {{input.sides.2}})))))
-{{/test_cases.equilateral~}}
+{{/test_cases.equilateral}}
+
 {{#test_cases.isosceles}}
 (deftest isosceles?_test_{{idx}}
   (testing {{description}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (triangle/isosceles? {{input.sides.0}} {{input.sides.1}} {{input.sides.2}})))))
-{{/test_cases.isosceles~}}
+{{/test_cases.isosceles}}
+
 {{#test_cases.scalene}}
 (deftest scalene?_test_{{idx}}
   (testing {{description}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (triangle/scalene? {{input.sides.0}} {{input.sides.1}} {{input.sides.2}})))))
-{{/test_cases.scalene~}}
+{{/test_cases.scalene}}

--- a/exercises/practice/twelve-days/.meta/generator.tpl
+++ b/exercises/practice/twelve-days/.meta/generator.tpl
@@ -2,10 +2,11 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.string :as str]
             twelve-days))
+
 {{#test_cases.recite}}
 (deftest recite_test_{{idx}}
   (testing {{description}}
-    (is (= (str/join "\n" [{{#expected~}}{{.}}{{#if @last}}]){{else}}
+    (is (= (str/join "\n" [{{#expected}}{{.}}{{#if @last}}]){{else}}
                            {{/if}}{{/expected}}
            (twelve-days/recite {{input.startVerse}} {{input.endVerse}})))))
-{{/test_cases.recite~}}
+{{/test_cases.recite}}

--- a/exercises/practice/two-fer/.meta/generator.tpl
+++ b/exercises/practice/two-fer/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns two-fer-test
   (:require [clojure.test :refer [deftest testing is]]
             two-fer))
+
 {{#test_cases.twoFer}}
 (deftest two-fer_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (two-fer/two-fer{{#input.name}} {{input.name}}{{/input.name}})))))
-{{/test_cases.twoFer~}}
+{{/test_cases.twoFer}}

--- a/exercises/practice/wordy/.meta/generator.tpl
+++ b/exercises/practice/wordy/.meta/generator.tpl
@@ -1,6 +1,7 @@
 (ns wordy-test
   (:require [clojure.test :refer [deftest testing is]]
             wordy))
+
 {{#test_cases.answer}}
 (deftest evaluate_test_{{idx}}
   (testing {{description}}
@@ -9,4 +10,4 @@
     {{else}}
     (is (= {{expected}} (wordy/evaluate {{input.question}})))))
     {{/if~}}
-{{/test_cases.answer~}}
+{{/test_cases.answer}}

--- a/exercises/practice/yacht/.meta/generator.tpl
+++ b/exercises/practice/yacht/.meta/generator.tpl
@@ -1,8 +1,9 @@
 (ns yacht-test
   (:require [clojure.test :refer [deftest testing is]]
             yacht))
+
 {{#test_cases.score}}
 (deftest score_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (yacht/score {{input.dice}} {{input.category}})))))
-{{/test_cases.score~}}
+{{/test_cases.score}}

--- a/exercises/practice/zebra-puzzle/.meta/generator.tpl
+++ b/exercises/practice/zebra-puzzle/.meta/generator.tpl
@@ -1,13 +1,15 @@
 (ns zebra-puzzle-test
   (:require [clojure.test :refer [deftest testing is]]
             zebra-puzzle))
+
 {{#test_cases.drinksWater}}
 (deftest drinks-water_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (zebra-puzzle/drinks-water)))))
-{{/test_cases.drinksWater~}}
+{{/test_cases.drinksWater}}
+
 {{#test_cases.ownsZebra}}
 (deftest owns-zebra_test_{{idx}}
   (testing {{description}}
     (is (= {{expected}} (zebra-puzzle/owns-zebra)))))
-{{/test_cases.ownsZebra~}}
+{{/test_cases.ownsZebra}}

--- a/generators/src/templates.clj
+++ b/generators/src/templates.clj
@@ -88,9 +88,14 @@
         data (update-vals grouped #(map-indexed test-case->data %))]
     {:test_cases data}))
 
+(defn template [slug]
+  (->> slug
+       (paths/generator-template-file)
+       (slurp)
+       (str/trim-newline)))
+
 (defn generate-test-files [slug test-cases]
-  (let [template (slurp (paths/generator-template-file slug))
-        data (test-cases->data slug test-cases)]
-    (->> (render reg template data)
-         (formatting/format-code)
-         (spit (paths/tests-file slug)))))
+  (->> (test-cases->data slug test-cases)
+       (render reg (template slug))
+       (formatting/format-code)
+       (spit (paths/tests-file slug))))


### PR DESCRIPTION
This is possible due to the use of cljfmt _after_ rendering the template.

I feel that less use of `~` makes it easier to read, as well as being able to separate multiple loops in a single template by a blank line.