### PR TITLE
Move formatting code to formatting namespace

### DIFF
--- a/generators/src/formatting.clj
+++ b/generators/src/formatting.clj
@@ -1,5 +1,27 @@
 (ns formatting
-  (:require [cljfmt.core :refer [reformat-string]]))
+  (:require [cljfmt.core :refer [reformat-string]]
+            [clojure.string :as str])
+  (:import [com.github.jknack.handlebars Formatter]))
 
 (defn format-code [code]
   (reformat-string code))
+
+(defn format-string [s _next]
+  (str "\"" (str/escape s char-escape-string) "\""))
+
+(defn format-collection [coll next open close]
+  (let [formatted-elements (str/join " " (map #(. next format %) coll))]
+    (str open formatted-elements close)))
+
+(defn format-list [coll next]
+  (format-collection coll next "'(" ")"))
+
+(defn format-set [coll next]
+  (format-collection coll next "#{" "}"))
+
+(defn formatter [test conv]
+  (proxy [Formatter] []
+    (format [value next]
+      (if (test value)
+        (conv value next)
+        (. next format value)))))

--- a/generators/src/templates.clj
+++ b/generators/src/templates.clj
@@ -6,33 +6,13 @@
             [log]
             [paths]
             [formatting])
-  (:import [com.github.jknack.handlebars Formatter EscapingStrategy]))
-
-(defn format-string [s _next]
-  (str "\"" (str/escape s char-escape-string) "\""))
-
-(defn format-collection [coll next open close]
-  (let [formatted-elements (str/join " " (map #(. next format %) coll))]
-    (str open formatted-elements close)))
-
-(defn format-list [coll next]
-  (format-collection coll next "'(" ")"))
-
-(defn format-set [coll next]
-  (format-collection coll next "#{" "}"))
-
-(defn formatter [test conv]
-  (proxy [Formatter] []
-    (format [value next]
-      (if (test value)
-        (conv value next)
-        (. next format value)))))
+  (:import [com.github.jknack.handlebars EscapingStrategy]))
 
 (def reg
   (-> *hbs*
-      (. with (formatter set? format-set))
-      (. with (formatter list? format-list))
-      (. with (formatter string? format-string))
+      (. with (formatting/formatter set? formatting/format-set))
+      (. with (formatting/formatter list? formatting/format-list))
+      (. with (formatting/formatter string? formatting/format-string))
       (. with EscapingStrategy/NOOP)))
 
 (defhelper ifzero [ctx options]


### PR DESCRIPTION
This attempts to separate formatting code from template rendering code a bit. Let me know what you think