### PR TITLE
hamming: Sync tests

### DIFF
--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -6,7 +6,8 @@
     "AndreaCrotti",
     "haus",
     "heyarne",
-    "sjwarner-bp"
+    "sjwarner-bp",
+    "tasxatzial"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/hamming/.meta/example.clj
+++ b/exercises/practice/hamming/.meta/example.clj
@@ -1,5 +1,6 @@
 (ns hamming)
 
 (defn distance [a b]
-  (when (= (count a) (count b))
-    (count (filter true? (map not= a b)))))
+  (if (= (count a) (count b))
+    (count (filter true? (map not= a b)))
+    (throw (IllegalArgumentException. "strands must be of equal length"))))

--- a/exercises/practice/hamming/.meta/generator.clj
+++ b/exercises/practice/hamming/.meta/generator.clj
@@ -1,0 +1,6 @@
+(ns hamming-generator)
+
+(defn update-test-case [test-case]
+  (if-let [error (get-in test-case [:expected :error])]
+    (assoc-in test-case [:expected :error] (str "^" error "$"))
+    test-case))

--- a/exercises/practice/hamming/.meta/generator.tpl
+++ b/exercises/practice/hamming/.meta/generator.tpl
@@ -1,0 +1,14 @@
+(ns hamming-test
+  (:require [clojure.test :refer [deftest testing is]]
+            hamming))
+
+{{#test_cases.distance}}
+(deftest distance_test_{{idx}}
+  (testing {{description}}
+    {{~#if error}}
+    (is (thrown-with-msg? IllegalArgumentException #{{error}}
+                          (hamming/distance {{input.strand1}} {{input.strand2}})))))
+    {{else}}
+    (is (= {{expected}} (hamming/hamming {{input.strand1}} {{input.strand2}})))))
+    {{/if~}}
+{{/test_cases.distance}}

--- a/exercises/practice/hamming/src/hamming.clj
+++ b/exercises/practice/hamming/src/hamming.clj
@@ -1,5 +1,7 @@
 (ns hamming)
 
-(defn distance [strand1 strand2] ; <- arglist goes here
-  ;; your code goes here
+(defn distance
+  "Returns the hamming distance between two DNA strands."
+  [strand1 strand2]
+  ;; function body
 )

--- a/exercises/practice/hamming/test/hamming_test.clj
+++ b/exercises/practice/hamming/test/hamming_test.clj
@@ -1,39 +1,43 @@
 (ns hamming-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest testing is]]
             hamming))
 
-(deftest empty-strands
-  (testing "Empty strands"
+(deftest distance_test_1
+  (testing "empty strands"
     (is (= 0 (hamming/distance "" "")))))
 
-(deftest single-letter-identical-strands
-  (testing "Single letter identical strands"
+(deftest distance_test_2
+  (testing "single letter identical strands"
     (is (= 0 (hamming/distance "A" "A")))))
 
-(deftest single-letter-different-strands
-  (testing "Single letter different strands"
+(deftest distance_test_3
+  (testing "single letter different strands"
     (is (= 1 (hamming/distance "G" "T")))))
 
-(deftest long-identical-strands
-  (testing "Long identical strands"
+(deftest distance_test_4
+  (testing "long identical strands"
     (is (= 0 (hamming/distance "GGACTGAAATCTG" "GGACTGAAATCTG")))))
 
-(deftest long-different-strands
-  (testing "Long different strands"
+(deftest distance_test_5
+  (testing "long different strands"
     (is (= 9 (hamming/distance "GGACGGATTCTG" "AGGACGGATTCT")))))
 
-(deftest disallow-first-strand-longer
-  (testing "Disallow first strand longer"
-    (is (= nil (hamming/distance "AATG" "AAA")))))
+(deftest distance_test_6
+  (testing "disallow first strand longer"
+    (is (thrown-with-msg? IllegalArgumentException #"^strands must be of equal length$"
+                          (hamming/distance "AATG" "AAA")))))
 
-(deftest disallow-second-strand-longer
-  (testing "Disallow second strand longer"
-    (is (= nil (hamming/distance "ATA" "AGTG")))))
+(deftest distance_test_7
+  (testing "disallow second strand longer"
+    (is (thrown-with-msg? IllegalArgumentException #"^strands must be of equal length$"
+                          (hamming/distance "ATA" "AGTG")))))
 
-(deftest disallow-empty-first-strand
-  (testing "Disallow empty first strand"
-    (is (= nil (hamming/distance "" "G")))))
+(deftest distance_test_8
+  (testing "disallow empty first strand"
+    (is (thrown-with-msg? IllegalArgumentException #"^strands must be of equal length$"
+                          (hamming/distance "" "G")))))
 
-(deftest disallow-empty-second-strand
-  (testing "Disallow empty second strand"
-    (is (= nil (hamming/distance "G" "")))))
+(deftest distance_test_9
+  (testing "disallow empty second strand"
+    (is (thrown-with-msg? IllegalArgumentException #"^strands must be of equal length$"
+                          (hamming/distance "G" "")))))


### PR DESCRIPTION
The current tests were returning `nil` for strands of unequal length. Admittedly, `nil` is one of the trickiest parts of the language, but this looks like an incorrect use of `nil` to me. I've replaced them with Exceptions but will revert if there's any disagreement.