### PR TITLE
series: Sync tests

### DIFF
--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -3,7 +3,8 @@
   "contributors": [
     "AndreaCrotti",
     "haus",
-    "sjwarner-bp"
+    "sjwarner-bp",
+    "tasxatzial"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/series/.meta/example.clj
+++ b/exercises/practice/series/.meta/example.clj
@@ -1,9 +1,11 @@
 (ns series)
 
-(defn slices [string n]
-  (if (zero? n)
-    [""]
-    (loop [string string, acc []]
-      (if (< (count string) n)
-        acc
-        (recur (rest string) (conj acc (apply str (take n string))))))))
+(defn slices [s n]
+  (cond
+    (= "" s) (throw (IllegalArgumentException. "series cannot be empty"))
+    (zero? n) (throw (IllegalArgumentException. "slice length cannot be zero"))
+    (neg? n) (throw (IllegalArgumentException. "slice length cannot be negative"))
+    (> n (.length s)) (throw (IllegalArgumentException. "slice length cannot be greater than series length")))
+  (->> s
+       (partition n 1)
+       (map #(apply str %))))

--- a/exercises/practice/series/.meta/generator.clj
+++ b/exercises/practice/series/.meta/generator.clj
@@ -1,0 +1,6 @@
+(ns series-generator)
+
+(defn update-test-case [test-case]
+  (if-let [error (get-in test-case [:expected :error])]
+    (assoc-in test-case [:expected :error] (str "^" error "$"))
+    test-case))

--- a/exercises/practice/series/.meta/generator.tpl
+++ b/exercises/practice/series/.meta/generator.tpl
@@ -1,0 +1,15 @@
+(ns series-test
+  (:require [clojure.test :refer [deftest testing is]]
+            series))
+
+{{#test_cases.slices}}
+(deftest slices_test_{{idx}}
+  (testing {{description}}
+    {{~#if error}}
+    (is (thrown-with-msg? IllegalArgumentException #{{error}}
+                          (series/slices {{input.series}} {{input.sliceLength}})))))
+    {{else}}
+    (is (= {{expected}}
+           (series/slices {{input.series}} {{input.sliceLength}})))))
+    {{/if~}}
+{{/test_cases.slices}}

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [7ae7a46a-d992-4c2a-9c15-a112d125ebad]
 description = "slices of one from one"
@@ -22,6 +29,9 @@ description = "slices of a long series"
 
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
+
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
 
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"

--- a/exercises/practice/series/src/series.clj
+++ b/exercises/practice/series/src/series.clj
@@ -1,5 +1,7 @@
 (ns series)
 
-(defn slices [string length] ;; <- arglist goes here
-  ;; your code goes here
-)
+(defn slices
+  "Returns all contiguous substrings of length n from the string s."
+  [s n]
+  ;; function body
+  )

--- a/exercises/practice/series/test/series_test.clj
+++ b/exercises/practice/series/test/series_test.clj
@@ -1,23 +1,58 @@
 (ns series-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [series :refer [slices]]))
+  (:require [clojure.test :refer [deftest testing is]]
+            series))
 
-(deftest empty-string
-  (testing "empty string with any number"
-    (is (= [] (slices "" 1)))))
+(deftest slices_test_1
+  (testing "slices of one from one"
+    (is (= ["1"]
+           (series/slices "1" 1)))))
 
-(deftest number-eq-zero
-  (testing "number = 0"
-    (is (= [""] (slices "123" 0)))))
+(deftest slices_test_2
+  (testing "slices of one from two"
+    (is (= ["1" "2"]
+           (series/slices "12" 1)))))
 
-(deftest number>string
-  (testing "number > string-length"
-    (is (= [] (slices "123" 1000)))))
+(deftest slices_test_3
+  (testing "slices of two"
+    (is (= ["35"]
+           (series/slices "35" 2)))))
 
-(deftest number=string
-  (testing "number = string-length"
-    (is (= ["123"] (slices "123" 3)))))
+(deftest slices_test_4
+  (testing "slices of two overlap"
+    (is (= ["91" "14" "42"]
+           (series/slices "9142" 2)))))
 
-(deftest number<string
-  (testing "number < string-length"
-    (is (= #{"123" "234" "345"} (set (slices "12345" 3))))))
+(deftest slices_test_5
+  (testing "slices can include duplicates"
+    (is (= ["777" "777" "777" "777"]
+           (series/slices "777777" 3)))))
+
+(deftest slices_test_6
+  (testing "slices of a long series"
+    (is (= ["91849" "18493" "84939" "49390" "93904" "39042" "90424" "04243"]
+           (series/slices "918493904243" 5)))))
+
+(deftest slices_test_7
+  (testing "slice length is too large"
+    (is (thrown-with-msg? IllegalArgumentException #"^slice length cannot be greater than series length$"
+                          (series/slices "12345" 6)))))
+
+(deftest slices_test_8
+  (testing "slice length is way too large"
+    (is (thrown-with-msg? IllegalArgumentException #"^slice length cannot be greater than series length$"
+                          (series/slices "12345" 42)))))
+
+(deftest slices_test_9
+  (testing "slice length cannot be zero"
+    (is (thrown-with-msg? IllegalArgumentException #"^slice length cannot be zero$"
+                          (series/slices "12345" 0)))))
+
+(deftest slices_test_10
+  (testing "slice length cannot be negative"
+    (is (thrown-with-msg? IllegalArgumentException #"^slice length cannot be negative$"
+                          (series/slices "123" -1)))))
+
+(deftest slices_test_11
+  (testing "empty series is invalid"
+    (is (thrown-with-msg? IllegalArgumentException #"^series cannot be empty$"
+                          (series/slices "" 1)))))


### PR DESCRIPTION
The order of argument checks regarding error cases is from the first argument to last (first argument is checked, if it does not throw error, then the second argument is checked and so on)

Edit: This applies only to the example solution. There are no test cases where both arguments result in an error.