### PR TITLE
matching-brackets: Add generator and regenerate tests

### DIFF
--- a/exercises/practice/matching-brackets/.meta/generator.tpl
+++ b/exercises/practice/matching-brackets/.meta/generator.tpl
@@ -1,0 +1,9 @@
+(ns matching-brackets-test
+  (:require [clojure.test :refer [deftest testing is]]
+            matching-brackets))
+
+{{#test_cases.isPaired}}
+(deftest valid?_test_{{idx}}
+  (testing {{description}}
+    (is ({{#expected}}true?{{else}}false?{{/expected}} (matching-brackets/valid? {{input.value}})))))
+{{/test_cases.isPaired}}

--- a/exercises/practice/matching-brackets/src/matching_brackets.clj
+++ b/exercises/practice/matching-brackets/src/matching_brackets.clj
@@ -1,6 +1,7 @@
 (ns matching-brackets)
 
 (defn valid?
+  "Returns true if the given string has properly matched brackets; otherwise, returns false."
   [s]
   ;; function body
   )

--- a/exercises/practice/matching-brackets/test/matching_brackets_test.clj
+++ b/exercises/practice/matching-brackets/test/matching_brackets_test.clj
@@ -45,7 +45,7 @@
 (deftest valid?_test_11
   (testing "unopened closing brackets"
     (is (false? (matching-brackets/valid? "{[)][]}")))))
- 
+
 (deftest valid?_test_12
   (testing "unpaired and nested brackets"
     (is (false? (matching-brackets/valid? "([{])")))))
@@ -80,4 +80,4 @@
 
 (deftest valid?_test_20
   (testing "complex latex expression"
-    (is (true? (matching-brackets/valid? "\\\\left(\\\\begin{array}{cc} \\\\frac{1}{3} & x\\\\\\\\ \\\\mathrm{e}^{x} &... x^2 \\\\end{array}\\\\right)")))))
+    (is (true? (matching-brackets/valid? "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)")))))


### PR DESCRIPTION
Last test had an extra `\` for each `\`, this has now been fixed.