### PR TITLE
generator: rename template variable

### DIFF
--- a/exercises/practice/acronym/.meta/generator.tpl
+++ b/exercises/practice/acronym/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.abbreviate}}
 (deftest acronym_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (acronym/acronym {{input.phrase}})))))
 {{/test_cases.abbreviate}}

--- a/exercises/practice/anagram/.meta/generator.tpl
+++ b/exercises/practice/anagram/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.findAnagrams}}
 (deftest anagrams-for_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}}
            (anagram/anagrams-for {{input.subject}} {{input.candidates}})))))
 {{/test_cases.findAnagrams}}

--- a/exercises/practice/armstrong-numbers/.meta/generator.tpl
+++ b/exercises/practice/armstrong-numbers/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.isArmstrongNumber}}
 (deftest armstrong?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (armstrong-numbers/armstrong? {{input.number}})))))
 {{/test_cases.isArmstrongNumber}}

--- a/exercises/practice/atbash-cipher/.meta/generator.tpl
+++ b/exercises/practice/atbash-cipher/.meta/generator.tpl
@@ -4,14 +4,14 @@
 
 {{#test_cases.encode}}
 (deftest encode_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}}
         (atbash-cipher/encode {{input.phrase}})))))
 {{/test_cases.encode}}
 
 {{#test_cases.decode}}
 (deftest decode_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}}
         (atbash-cipher/decode {{input.phrase}})))))
 {{/test_cases.decode}}

--- a/exercises/practice/change/.meta/generator.tpl
+++ b/exercises/practice/change/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.findFewestCoins}}
 (deftest issue_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}}
                           (change/issue {{input.target}} {{input.coins}})))))

--- a/exercises/practice/collatz-conjecture/.meta/generator.tpl
+++ b/exercises/practice/collatz-conjecture/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.steps}}
 (deftest collatz_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}}
                           (collatz-conjecture/collatz {{input.number}})))))

--- a/exercises/practice/connect/.meta/generator.tpl
+++ b/exercises/practice/connect/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.winner}}
 (deftest connect-winner_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}}
            (connect/connect-winner
              [{{#input.board~}}

--- a/exercises/practice/darts/.meta/generator.tpl
+++ b/exercises/practice/darts/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.score}}
 (deftest score_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (darts/score {{input.x}} {{input.y}})))))
 {{/test_cases.score}}

--- a/exercises/practice/diamond/.meta/generator.tpl
+++ b/exercises/practice/diamond/.meta/generator.tpl
@@ -5,7 +5,7 @@
 
 {{#test_cases.rows}}
 (deftest diamond_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= (str/join "\n" [{{#expected}}
                            {{.}}{{/expected}}])
            (diamond/diamond {{input.letter}})))))

--- a/exercises/practice/difference-of-squares/.meta/generator.tpl
+++ b/exercises/practice/difference-of-squares/.meta/generator.tpl
@@ -4,18 +4,18 @@
 
 {{#test_cases.squareOfSum}}
 (deftest square-of-sum_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (difference-of-squares/square-of-sum {{input.number}})))))
 {{/test_cases.squareOfSum}}
 
 {{#test_cases.sumOfSquares}}
 (deftest sum-of-squares_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (difference-of-squares/sum-of-squares {{input.number}})))))
 {{/test_cases.sumOfSquares}}
 
 {{#test_cases.differenceOfSquares}}
 (deftest difference_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (difference-of-squares/difference {{input.number}})))))
 {{/test_cases.differenceOfSquares}}

--- a/exercises/practice/dnd-character/.meta/generator.tpl
+++ b/exercises/practice/dnd-character/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.modifier}}
 (deftest score-modifier_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (dnd-character/score-modifier {{input.score}})))))
 {{/test_cases.modifier}}
 
@@ -19,7 +19,7 @@
 
 {{#test_cases.character}}
 (deftest rand-character_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (dotimes [_ 100]
       (is (<= 3 ({{ability}} (dnd-character/rand-character)) 18)))))
 {{/test_cases.character}}

--- a/exercises/practice/dominoes/.meta/generator.tpl
+++ b/exercises/practice/dominoes/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.canChain}}
 (deftest can-chain?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (dominoes/can-chain? {{input.dominoes}})))))
 {{/test_cases.canChain}}

--- a/exercises/practice/eliuds-eggs/.meta/generator.tpl
+++ b/exercises/practice/eliuds-eggs/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.eggCount}}
 (deftest egg-count_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (eliuds-eggs/egg-count {{input.number}})))))
 {{/test_cases.eggCount}}

--- a/exercises/practice/food-chain/.meta/generator.tpl
+++ b/exercises/practice/food-chain/.meta/generator.tpl
@@ -5,7 +5,7 @@
 
 {{#test_cases.recite}}
 (deftest recite_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= (str/join "\n" [{{#expected~}}{{.}}{{#if @last}}]){{else}}
                            {{/if}}{{/expected}}
            (food-chain/recite {{input.startVerse}} {{input.endVerse}})))))

--- a/exercises/practice/game-of-life/.meta/generator.tpl
+++ b/exercises/practice/game-of-life/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.tick}}
 (deftest tick_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is
       (= [{{#expected~}}
           {{.}}

--- a/exercises/practice/grains/.meta/generator.tpl
+++ b/exercises/practice/grains/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.square}}
 (deftest square_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}}
                           (grains/square {{input.square}})))))
@@ -15,6 +15,6 @@
 
 {{#test_cases.total}}
 (deftest total_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (grains/total)))))
 {{/test_cases.total}}

--- a/exercises/practice/hamming/.meta/generator.tpl
+++ b/exercises/practice/hamming/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.distance}}
 (deftest distance_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}}
                           (hamming/distance {{input.strand1}} {{input.strand2}})))))

--- a/exercises/practice/high-scores/.meta/generator.tpl
+++ b/exercises/practice/high-scores/.meta/generator.tpl
@@ -4,24 +4,24 @@
 
 {{#test_cases.scores}}
 (deftest scores_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (high-scores/scores {{input.scores}})))))
 {{/test_cases.scores}}
 
 {{#test_cases.latest}}
 (deftest latest_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (high-scores/latest {{input.scores}})))))
 {{/test_cases.latest}}
 
 {{#test_cases.personalBest}}
 (deftest personal-best_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (high-scores/personal-best {{input.scores}})))))
 {{/test_cases.personalBest}}
 
 {{#test_cases.personalTopThree}}
 (deftest personal-top-three_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (high-scores/personal-top-three {{input.scores}})))))
 {{/test_cases.personalTopThree}}

--- a/exercises/practice/isbn-verifier/.meta/generator.tpl
+++ b/exercises/practice/isbn-verifier/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.isValid}}
 (deftest isbn?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (isbn-verifier/isbn? {{input.isbn}})))))
 {{/test_cases.isValid}}

--- a/exercises/practice/isogram/.meta/generator.tpl
+++ b/exercises/practice/isogram/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.isIsogram}}
 (deftest isogram?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (isogram/isogram? {{input.phrase}})))))
 {{/test_cases.isIsogram}}

--- a/exercises/practice/killer-sudoku-helper/.meta/generator.tpl
+++ b/exercises/practice/killer-sudoku-helper/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.combinations}}
 (deftest combinations_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (killer-sudoku-helper/combinations {:sum {{input.cage.sum}} :size {{input.cage.size}} :exclude {{input.cage.exclude~}} })))))
 {{/test_cases.combinations}}

--- a/exercises/practice/knapsack/.meta/generator.tpl
+++ b/exercises/practice/knapsack/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.maximumValue}}
 (deftest maximum-value_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (knapsack/maximum-value {{input.maximumWeight}} [{{#input.items}}
      {{.}}{{/input.items}}])))))
 {{/test_cases.maximumValue}}

--- a/exercises/practice/largest-series-product/.meta/generator.tpl
+++ b/exercises/practice/largest-series-product/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.largestProduct}}
 (deftest largest-product_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}} (largest-series-product/largest-product {{input.span}} {{input.digits}})))))
     {{else}}

--- a/exercises/practice/leap/.meta/generator.tpl
+++ b/exercises/practice/leap/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.leapYear}}
 (deftest leap-year?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (leap/leap-year? {{input.year}})))))
 {{/test_cases.leapYear}}

--- a/exercises/practice/matching-brackets/.meta/generator.tpl
+++ b/exercises/practice/matching-brackets/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.isPaired}}
 (deftest valid?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (matching-brackets/valid? {{input.value}})))))
 {{/test_cases.isPaired}}

--- a/exercises/practice/matrix/.meta/generator.tpl
+++ b/exercises/practice/matrix/.meta/generator.tpl
@@ -4,12 +4,12 @@
 
 {{#test_cases.row}}
 (deftest get-row_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (matrix/get-row {{input.string}} {{input.index}})))))
 {{/test_cases.row}}
 
 {{#test_cases.column}}
 (deftest get-column_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (matrix/get-column {{input.string}} {{input.index}})))))
 {{/test_cases.column}}

--- a/exercises/practice/pangram/.meta/generator.tpl
+++ b/exercises/practice/pangram/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.isPangram}}
 (deftest pangram?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (pangram/pangram? {{input.sentence}})))))
 {{/test_cases.isPangram}}

--- a/exercises/practice/pig-latin/.meta/generator.tpl
+++ b/exercises/practice/pig-latin/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.translate}}
 (deftest translate_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (pig-latin/translate {{input.phrase}})))))
 {{/test_cases.translate}}

--- a/exercises/practice/pythagorean-triplet/.meta/generator.tpl
+++ b/exercises/practice/pythagorean-triplet/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.tripletsWithSum}}
 (deftest find-pythagorean-triplets_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= [{{#expected~}}
             {{.}}
             {{/expected}}]

--- a/exercises/practice/resistor-color-duo/.meta/generator.tpl
+++ b/exercises/practice/resistor-color-duo/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.value}}
 (deftest resistor-value_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (resistor-color-duo/resistor-value {{input.colors}})))))
 {{/test_cases.value}}

--- a/exercises/practice/resistor-color-trio/.meta/generator.tpl
+++ b/exercises/practice/resistor-color-trio/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.label}}
 (deftest resistor-label_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (resistor-color-trio/resistor-label {{input.colors}})))))
 {{/test_cases.label}}

--- a/exercises/practice/resistor-color/.meta/generator.tpl
+++ b/exercises/practice/resistor-color/.meta/generator.tpl
@@ -4,13 +4,13 @@
 
 {{#test_cases.colors}}
 (deftest colors_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}}
            resistor-color/colors))))
 {{/test_cases.colors}}
 
 {{#test_cases.colorCode}}
 (deftest color-code_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (resistor-color/color-code {{input.color}})))))
 {{/test_cases.colorCode}}

--- a/exercises/practice/reverse-string/.meta/generator.tpl
+++ b/exercises/practice/reverse-string/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.reverse}}
 (deftest reverse-string_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (reverse-string/reverse-string {{input.value}})))))
 {{/test_cases.reverse}}

--- a/exercises/practice/rna-transcription/.meta/generator.tpl
+++ b/exercises/practice/rna-transcription/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.toRna}}
 (deftest to-rna_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (rna-transcription/to-rna {{input.dna}})))))
 {{/test_cases.toRna}}

--- a/exercises/practice/roman-numerals/.meta/generator.tpl
+++ b/exercises/practice/roman-numerals/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.roman}}
 (deftest numerals_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (roman-numerals/numerals {{input.number}})))))
 {{/test_cases.roman}}

--- a/exercises/practice/saddle-points/.meta/generator.tpl
+++ b/exercises/practice/saddle-points/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.saddlePoints}}
 (deftest saddle-points_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}}
            (saddle-points/saddle-points
              [{{#input.matrix}}

--- a/exercises/practice/scrabble-score/.meta/generator.tpl
+++ b/exercises/practice/scrabble-score/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.score}}
 (deftest score-word_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (scrabble-score/score-word {{input.word}})))))
 {{/test_cases.score}}

--- a/exercises/practice/series/.meta/generator.tpl
+++ b/exercises/practice/series/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.slices}}
 (deftest slices_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}}
                           (series/slices {{input.series}} {{input.sliceLength}})))))

--- a/exercises/practice/simple-cipher/.meta/generator.tpl
+++ b/exercises/practice/simple-cipher/.meta/generator.tpl
@@ -4,13 +4,13 @@
 
 {{#test_cases.key}}
 (deftest rand-key_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (true? (boolean (re-matches #{{expected.match}} (simple-cipher/rand-key)))))))
 {{/test_cases.key}}
 
 {{#test_cases.encode}}
 (deftest encode_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{#if input.key~}}
     (is (= {{expected}} (simple-cipher/encode {{input.key}} {{input.plaintext}})))))
     {{else~}}
@@ -21,7 +21,7 @@
 
 {{#test_cases.decode}}
 (deftest decode_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{#if input.key~}}
     (is (= {{expected}} (simple-cipher/decode {{input.key}} {{#if input.plaintext}}(simple-cipher/encode {{input.key}} {{input.plaintext}}{{else}}{{input.ciphertext}}{{/if}}))))))
     {{else~}}

--- a/exercises/practice/space-age/.meta/generator.tpl
+++ b/exercises/practice/space-age/.meta/generator.tpl
@@ -9,6 +9,6 @@
 
 {{#test_cases.age}}
 (deftest on-{{input.planet}}_test_1
-  (testing {{description}}  
+  (testing {{context}}  
     (rounds-to {{expected}} (space-age/on-{{input.planet}} {{input.seconds}}))))
 {{/test_cases.age}}

--- a/exercises/practice/square-root/.meta/generator.tpl
+++ b/exercises/practice/square-root/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.squareRoot}}
 (deftest square-root_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (square-root/square-root {{input.radicand}})))))
 {{/test_cases.squareRoot}}

--- a/exercises/practice/state-of-tic-tac-toe/.meta/generator.tpl
+++ b/exercises/practice/state-of-tic-tac-toe/.meta/generator.tpl
@@ -3,7 +3,7 @@
             state-of-tic-tac-toe))
 {{#test_cases.gamestate}}
 (deftest gamestate_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if expected.error}}
     (is (thrown-with-msg? IllegalArgumentException #{{expected.error}}
                           (state-of-tic-tac-toe/gamestate 

--- a/exercises/practice/sublist/.meta/generator.tpl
+++ b/exercises/practice/sublist/.meta/generator.tpl
@@ -3,6 +3,6 @@
             sublist))
 {{#test_cases.sublist}}
 (deftest classify_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (sublist/classify {{input.listOne}} {{input.listTwo}})))))
 {{/test_cases.sublist~}}

--- a/exercises/practice/sum-of-multiples/.meta/generator.tpl
+++ b/exercises/practice/sum-of-multiples/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.sum}}
 (deftest sum-of-multiples_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#ifzero expected}}zero?{{else}}= {{expected}}{{/ifzero}} (sum-of-multiples/sum-of-multiples {{input.factors}} {{input.limit}})))))
 {{/test_cases.sum}}

--- a/exercises/practice/transpose/.meta/generator.tpl
+++ b/exercises/practice/transpose/.meta/generator.tpl
@@ -5,7 +5,7 @@
 
 {{#test_cases.transpose}}
 (deftest transpose_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= (str/join "\n" [{{#expected~}}
                            {{.}}
                            {{/expected}}])

--- a/exercises/practice/triangle/.meta/generator.tpl
+++ b/exercises/practice/triangle/.meta/generator.tpl
@@ -4,18 +4,18 @@
 
 {{#test_cases.equilateral}}
 (deftest equilateral?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (triangle/equilateral? {{input.sides.0}} {{input.sides.1}} {{input.sides.2}})))))
 {{/test_cases.equilateral}}
 
 {{#test_cases.isosceles}}
 (deftest isosceles?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (triangle/isosceles? {{input.sides.0}} {{input.sides.1}} {{input.sides.2}})))))
 {{/test_cases.isosceles}}
 
 {{#test_cases.scalene}}
 (deftest scalene?_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is ({{#expected}}true?{{else}}false?{{/expected}} (triangle/scalene? {{input.sides.0}} {{input.sides.1}} {{input.sides.2}})))))
 {{/test_cases.scalene}}

--- a/exercises/practice/twelve-days/.meta/generator.tpl
+++ b/exercises/practice/twelve-days/.meta/generator.tpl
@@ -5,7 +5,7 @@
 
 {{#test_cases.recite}}
 (deftest recite_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= (str/join "\n" [{{#expected}}{{.}}{{#if @last}}]){{else}}
                            {{/if}}{{/expected}}
            (twelve-days/recite {{input.startVerse}} {{input.endVerse}})))))

--- a/exercises/practice/two-fer/.meta/generator.tpl
+++ b/exercises/practice/two-fer/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.twoFer}}
 (deftest two-fer_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (two-fer/two-fer{{#input.name}} {{input.name}}{{/input.name}})))))
 {{/test_cases.twoFer}}

--- a/exercises/practice/wordy/.meta/generator.tpl
+++ b/exercises/practice/wordy/.meta/generator.tpl
@@ -4,7 +4,7 @@
 
 {{#test_cases.answer}}
 (deftest evaluate_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     {{~#if error}}
     (is (thrown-with-msg? IllegalArgumentException #{{error}} (wordy/evaluate {{input.question}})))))
     {{else}}

--- a/exercises/practice/yacht/.meta/generator.tpl
+++ b/exercises/practice/yacht/.meta/generator.tpl
@@ -4,6 +4,6 @@
 
 {{#test_cases.score}}
 (deftest score_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (yacht/score {{input.dice}} {{input.category}})))))
 {{/test_cases.score}}

--- a/exercises/practice/zebra-puzzle/.meta/generator.tpl
+++ b/exercises/practice/zebra-puzzle/.meta/generator.tpl
@@ -4,12 +4,12 @@
 
 {{#test_cases.drinksWater}}
 (deftest drinks-water_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (zebra-puzzle/drinks-water)))))
 {{/test_cases.drinksWater}}
 
 {{#test_cases.ownsZebra}}
 (deftest owns-zebra_test_{{idx}}
-  (testing {{description}}
+  (testing {{context}}
     (is (= {{expected}} (zebra-puzzle/owns-zebra)))))
 {{/test_cases.ownsZebra}}

--- a/generators/src/templates.clj
+++ b/generators/src/templates.clj
@@ -39,7 +39,7 @@
 (defn- test-case->data [idx node]
   (-> node
       (assoc :idx (inc idx)
-             :description (str/join " ▶ " (:path node))
+             :context (str/join " ▶ " (:path node))
              :error (get-in node [:expected :error]))
       (dissoc :reimplements :comments :scenarios)))
 


### PR DESCRIPTION
This is done in preparation of changing the order of the generator calls, as we want to keep the `:description` from the canonical data and not overwrite it. I'm open to naming suggestions.
