### PR TITLE
list-ops: Add generators and regenerate tests

### DIFF
--- a/exercises/practice/list-ops/.meta/generator.clj
+++ b/exercises/practice/list-ops/.meta/generator.clj
@@ -1,0 +1,47 @@
+(ns list-ops-generator
+  (:require [clojure.string :as str]
+            [hbs.helper :refer [safe-str]]))
+
+(def ^:private patterns->test-type
+  {#"(?i)append" "Append"
+   #"(?i)concatenate" "Concatenate"
+   #"(?i)filter" "Filter"
+   #"(?i)length" "Length"
+   #"(?i)transform" "Map"
+   #"(?i)reverse" "Reverse"
+   #"(?i)fold.*left" "Foldl"
+   #"(?i)fold.*right" "Foldr"})
+
+(defn- specs-fn->clojure-fn [f]
+  (case f
+    "(x) -> x modulo 2 == 1" "odd?"
+    "(x) -> x + 1" "inc"
+    ("(x, y) -> x * y" "(acc, el) -> el * acc") "(fn [acc el] (* el acc))"
+    ("(x, y) -> x + y" "(acc, el) -> el + acc") "(fn [acc el] (+ el acc))"
+    ("(x, y) -> x / y" "(acc, el) -> el / acc") "(fn [acc el] (/ el acc))"))
+
+(defn- test-case-type [path]
+  (let [parent-description (first path)]
+    (->> patterns->test-type
+         (some #(when (re-find (key %) parent-description) (val %))))))
+
+(defn- update-description [path]
+  (-> path
+      second
+      (str/replace #"list" "vector")))
+
+(defn- create-context [test-case]
+  (let [path (:path test-case)
+        test-type (test-case-type path)
+        new-description (update-description path)]
+    (str test-type " ▶ " new-description)))
+
+(defn- update-input [input]
+  (if-let [f (get input :function)]
+    (assoc input :function (-> f specs-fn->clojure-fn safe-str))
+    input))
+
+(defn update-test-case [test-case]
+  (-> test-case
+      (assoc :context (create-context test-case))
+      (update :input update-input)))

--- a/exercises/practice/list-ops/.meta/generator.tpl
+++ b/exercises/practice/list-ops/.meta/generator.tpl
@@ -1,0 +1,56 @@
+(ns list-ops-test
+  (:require [clojure.test :refer [deftest testing is]]
+            list-ops))
+
+{{#test_cases.append}}
+(deftest append_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}}
+           (list-ops/append {{input.list1}} {{input.list2}})))))
+{{/test_cases.append}}
+
+{{#test_cases.concat}}
+(deftest concatenate_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}}
+           (list-ops/concatenate {{input.lists}})))))
+{{/test_cases.concat}}
+
+{{#test_cases.filter}}
+(deftest select-if_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}}
+           (list-ops/select-if {{input.function}} {{input.list}})))))
+{{/test_cases.filter}}
+
+{{#test_cases.length}}
+(deftest length_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}} (list-ops/length {{input.list}})))))
+{{/test_cases.length}}
+
+{{#test_cases.map}}
+(deftest apply-to-each_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}}
+           (list-ops/apply-to-each {{input.function}} {{input.list}})))))
+{{/test_cases.map}}
+
+{{#test_cases.foldl}}
+(deftest foldl_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}} (list-ops/foldl {{input.function}} {{input.list}} {{input.initial}})))))
+{{/test_cases.foldl}}
+
+{{#test_cases.foldr}}
+(deftest foldr_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}} (list-ops/foldr {{input.function}} {{input.list}} {{input.initial}})))))
+{{/test_cases.foldr}}
+
+{{#test_cases.reverse}}
+(deftest reverse-order_test_{{idx}}
+  (testing {{context}}
+    (is (= {{expected}}
+           (list-ops/reverse-order {{input.list}})))))
+{{/test_cases.reverse}}

--- a/exercises/practice/list-ops/test/list_ops_test.clj
+++ b/exercises/practice/list-ops/test/list_ops_test.clj
@@ -1,91 +1,105 @@
 (ns list-ops-test
   (:require [clojure.test :refer [deftest testing is]]
-             list-ops))
+            list-ops))
 
 (deftest append_test_1
-  (testing "append entries to a vector and return the new vector -> empty vectors"
-    (is (= [] (list-ops/append [] [])))))
+  (testing "Append ▶ empty vectors"
+    (is (= []
+           (list-ops/append [] [])))))
 
 (deftest append_test_2
-  (testing "append entries to a vector and return the new vector -> vector to empty vector"
-    (is (= [1 2 3 4] (list-ops/append [] [1 2 3 4])))))
+  (testing "Append ▶ vector to empty vector"
+    (is (= [1 2 3 4]
+           (list-ops/append [] [1 2 3 4])))))
 
 (deftest append_test_3
-  (testing "append entries to a vector and return the new vector -> empty vector to vector"
-    (is (= [1 2 3 4] (list-ops/append [1 2 3 4] [])))))
+  (testing "Append ▶ empty vector to vector"
+    (is (= [1 2 3 4]
+           (list-ops/append [1 2 3 4] [])))))
 
 (deftest append_test_4
-  (testing "append entries to a vector and return the new vector -> non-empty vectors"
-    (is (= [1 2 2 3 4 5] (list-ops/append [1 2] [2 3 4 5])))))
+  (testing "Append ▶ non-empty vectors"
+    (is (= [1 2 2 3 4 5]
+           (list-ops/append [1 2] [2 3 4 5])))))
 
 (deftest concatenate_test_1
-  (testing "concatenate a vector of vectors -> empty vector"
-    (is (= [] (list-ops/concatenate [])))))
+  (testing "Concatenate ▶ empty vector"
+    (is (= []
+           (list-ops/concatenate [])))))
 
 (deftest concatenate_test_2
-  (testing "concatenate a vector of vectors -> vector of vectors"
-    (is (= [1 2 3 4 5 6] (list-ops/concatenate [[1 2] [3] [] [4 5 6]])))))
+  (testing "Concatenate ▶ vector of vectors"
+    (is (= [1 2 3 4 5 6]
+           (list-ops/concatenate [[1 2] [3] [] [4 5 6]])))))
 
 (deftest concatenate_test_3
-  (testing "concatenate a vector of vectors -> vector of nested vectors"
-    (is (= [[1] [2] [3] [] [4 5 6]] (list-ops/concatenate [[[1] [2]] [[3]] [[]] [[4 5 6]]])))))
+  (testing "Concatenate ▶ vector of nested vectors"
+    (is (= [[1] [2] [3] [] [4 5 6]]
+           (list-ops/concatenate [[[1] [2]] [[3]] [[]] [[4 5 6]]])))))
 
 (deftest select-if_test_1
-  (testing "filter vector returning only values that satisfy the filter function -> empty vector"
-    (is (= [] (list-ops/select-if (fn [x] (= (mod x 2) 1)) [])))))
+  (testing "Filter ▶ empty vector"
+    (is (= []
+           (list-ops/select-if odd? [])))))
 
 (deftest select-if_test_2
-  (testing "filter vector returning only values that satisfy the filter function -> non-empty vector"
-    (is (= [1 3 5] (list-ops/select-if (fn [x] (= (mod x 2) 1)) [1 2 3 5])))))
+  (testing "Filter ▶ non-empty vector"
+    (is (= [1 3 5]
+           (list-ops/select-if odd? [1 2 3 5])))))
 
 (deftest length_test_1
-  (testing "returns the length of a vector -> empty vector"
+  (testing "Length ▶ empty vector"
     (is (= 0 (list-ops/length [])))))
 
 (deftest length_test_2
-  (testing "returns the length of a vector -> non-empty vector"
+  (testing "Length ▶ non-empty vector"
     (is (= 4 (list-ops/length [1 2 3 4])))))
 
 (deftest apply-to-each_test_1
-  (testing "return a vector of elements whose values equal the vector value transformed by the mapping function -> empty vector"
-    (is (= [] (list-ops/apply-to-each (fn [x] (+ x 1)) [])))))
+  (testing "Map ▶ empty vector"
+    (is (= []
+           (list-ops/apply-to-each inc [])))))
 
 (deftest apply-to-each_test_2
-  (testing "return a vector of elements whose values equal the vector value transformed by the mapping function -> non-empty vector"
-    (is (= [2 4 6 8] (list-ops/apply-to-each (fn [x] (+ x 1)) [1 3 5 7])))))
+  (testing "Map ▶ non-empty vector"
+    (is (= [2 4 6 8]
+           (list-ops/apply-to-each inc [1 3 5 7])))))
 
 (deftest foldl_test_1
-  (testing "folds (reduces) the given vector from the left with a function -> empty vector"
+  (testing "Foldl ▶ empty vector"
     (is (= 2 (list-ops/foldl (fn [acc el] (* el acc)) [] 2)))))
 
 (deftest foldl_test_2
-  (testing "folds (reduces) the given vector from the left with a function -> direction independent function applied to non-empty vector"
+  (testing "Foldl ▶ direction independent function applied to non-empty vector"
     (is (= 15 (list-ops/foldl (fn [acc el] (+ el acc)) [1 2 3 4] 5)))))
 
 (deftest foldl_test_3
-  (testing "folds (reduces) the given vector from the left with a function -> direction dependent function applied to non-empty vector"
+  (testing "Foldl ▶ direction dependent function applied to non-empty vector"
     (is (= 64 (list-ops/foldl (fn [acc el] (/ el acc)) [1 2 3 4] 24)))))
 
 (deftest foldr_test_1
-  (testing "folds (reduces) the given vector from the right with a function -> empty vector"
+  (testing "Foldr ▶ empty vector"
     (is (= 2 (list-ops/foldr (fn [acc el] (* el acc)) [] 2)))))
 
 (deftest foldr_test_2
-  (testing "folds (reduces) the given vector from the right with a function -> direction independent function applied to non-empty vector"
+  (testing "Foldr ▶ direction independent function applied to non-empty vector"
     (is (= 15 (list-ops/foldr (fn [acc el] (+ el acc)) [1 2 3 4] 5)))))
 
 (deftest foldr_test_3
-  (testing "folds (reduces) the given vector from the right with a function -> direction dependent function applied to non-empty vector"
+  (testing "Foldr ▶ direction dependent function applied to non-empty vector"
     (is (= 9 (list-ops/foldr (fn [acc el] (/ el acc)) [1 2 3 4] 24)))))
 
 (deftest reverse-order_test_1
-  (testing "reverse the elements of the vector -> empty vector"
-    (is (= [] (list-ops/reverse-order [])))))
+  (testing "Reverse ▶ empty vector"
+    (is (= []
+           (list-ops/reverse-order [])))))
 
 (deftest reverse-order_test_2
-  (testing "reverse the elements of the vector -> non-empty vector"
-    (is (= [7 5 3 1] (list-ops/reverse-order [1 3 5 7])))))
+  (testing "Reverse ▶ non-empty vector"
+    (is (= [7 5 3 1]
+           (list-ops/reverse-order [1 3 5 7])))))
 
 (deftest reverse-order_test_3
-  (testing "reverse the elements of the vector -> vector of vectors is not flattened"
-    (is (= [[4 5 6] [] [3] [1 2]] (list-ops/reverse-order [[1 2] [3] [] [4 5 6]])))))
+  (testing "Reverse ▶ vector of vectors is not flattened"
+    (is (= [[4 5 6] [] [3] [1 2]]
+           (list-ops/reverse-order [[1 2] [3] [] [4 5 6]])))))


### PR DESCRIPTION
Trimmed the parent descriptions so that they only contain the function names found in the docs.