### PR TITLE
Fix test runner alias - update deps.edn for squeaky-clean

### DIFF
--- a/exercises/concept/squeaky-clean/deps.edn
+++ b/exercises/concept/squeaky-clean/deps.edn
@@ -1,4 +1,5 @@
-{:aliases {:test {:extra-paths ["test"]
-                  :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                          :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
-                  :main-opts ["-m" "cognitect.test-runner"]}}}
+:aliases {:test {:extra-paths ["test"]
+                 :extra-deps {io.github.cognitect-labs/test-runner 
+                              {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 :main-opts ["-m" "cognitect.test-runner"]
+                 :exec-fn cognitect.test-runner.api/test}}

--- a/exercises/concept/squeaky-clean/deps.edn
+++ b/exercises/concept/squeaky-clean/deps.edn
@@ -1,5 +1,6 @@
-:aliases {:test {:extra-paths ["test"]
-                 :extra-deps {io.github.cognitect-labs/test-runner 
-                              {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-                 :main-opts ["-m" "cognitect.test-runner"]
-                 :exec-fn cognitect.test-runner.api/test}}
+{:aliases {:test {:extra-paths ["test"]
+                  :extra-deps {io.github.cognitect-labs/test-runner
+                               {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                :sha "705ad25bbf0228b1c38d0244a36001c2987d7337"}}
+                  :main-opts ["-m" "cognitect.test-runner"]
+                  :exec-fn cognitect.test-runner.api/test}}}


### PR DESCRIPTION
Tests fail to run with current deps.edn when using the test alias or exercism test.