### PR TITLE
Remove REPL test-running instructions from shared docs

### DIFF
--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -5,7 +5,7 @@
 The Clojure exercises on Exercism ship with a `deps.edn` file with a `:test` alias to invoke the [cognitect-labs test-runner](https://github.com/cognitect-labs/test-runner):
 
 ``` bash
-$ clj -X:test
+clj -X:test
 ```
 
 ## Leiningen
@@ -14,32 +14,4 @@ Leiningen can also be used to run the exercise's test by running the following c
 
 ```bash
 lein test
-```
-
-## REPL
-
-To use the REPL to run the exercise's test, run the following command from the exercise's directory:
-
-```bash
-$ clj
-```
-
--or-
-
-```bash
-$ lein repl
-```
-
-Then `require` the exercise's test namespace and the Clojure test namespace):
-
-```clojure
-;; replace <exercise> with the exercise's name
-=> (require '<exercise>-test)
-```
-
-Then call `run-tests` on `<exercise>-test`:
-
-```clojure
-;; replace <exercise> with the exercise's name
-=> (clojure.test/run-tests '<exercise>-test)
 ```


### PR DESCRIPTION
Forum topic https://forum.exercism.org/t/help-md-testing-in-repl-without-leiningen-fails/18529

This removes the instructions for running tests from REPL for two reasons:

1. They don't seem to work when using the Clojure CLI
2. They don't offer any advantage over the other existing test methods

If we ever have a section in the docs about using the REPL for development, we can add them back and potentially expand them. For now, it's safe to remove them.