### PR TITLE
annalyns-infiltration: Fix clashing deftest names

### DIFF
--- a/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
+++ b/exercises/concept/annalyns-infiltration/test/annalyns_infiltration_test.clj
@@ -82,7 +82,7 @@
   (testing "Cannot release prisoner if only knight is awake and pet dog is absent"
     (is (= false (annalyns-infiltration/can-free-prisoner? true false false false)))))
 
-(deftest ^{:task 4} release-prisoner-knight-awake-dog-present-test
+(deftest ^{:task 4} release-prisoner-knight-asleep-dog-present-test
   (testing "Cannot release prisoner if only knight is asleep and pet dog is present"
     (is (= false (annalyns-infiltration/can-free-prisoner? false true true true)))))
 


### PR DESCRIPTION
Two deftests had identical names, which caused the test runners to skip one of them. Turns out one of them was named incorrectly.