### PR TITLE
squeaky-clean: Add the ability to select which tests to run

### DIFF
--- a/exercises/concept/squeaky-clean/project.clj
+++ b/exercises/concept/squeaky-clean/project.clj
@@ -1,4 +1,9 @@
 (defproject squeaky-clean "0.1.0-SNAPSHOT"
   :description "squeaky-clean exercise."
   :url "https://github.com/exercism/clojure/tree/main/exercises/concept/squeaky-clean"
-  :dependencies [[org.clojure/clojure "1.12.0"]])
+  :dependencies [[org.clojure/clojure "1.12.0"]]
+  :test-selectors {:task-1 :task-1
+                   :task-2 :task-2
+                   :task-3 :task-3
+                   :task-4 :task-4
+                   :task-5 :task-5})

--- a/exercises/concept/squeaky-clean/src/squeaky_clean.clj
+++ b/exercises/concept/squeaky-clean/src/squeaky_clean.clj
@@ -2,6 +2,5 @@
   (:require [clojure.string :as str]))
 
 (defn clean
-  "TODO: add docstring"
   [s]
   )

--- a/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
+++ b/exercises/concept/squeaky-clean/test/squeaky_clean_test.clj
@@ -2,32 +2,32 @@
   (:require [clojure.test :refer [deftest is]]
             squeaky-clean))
 
-(deftest ^{:task 1} clean-single-letter
+(deftest ^{:task 1 :task-1 true} clean-single-letter
   (is (= "A" (squeaky-clean/clean "A"))))
 
-(deftest ^{:task 1} clean-clean-string
+(deftest ^{:task 1 :task-1 true} clean-clean-string
   (is (= "àḃç" (squeaky-clean/clean "àḃç"))))
 
-(deftest ^{:task 1} clean-string-with-spaces
+(deftest ^{:task 1 :task-1 true} clean-string-with-spaces
   (is (= "my___Id" (squeaky-clean/clean "my   Id"))))
 
-(deftest ^{:task 1} clean-empty-string
+(deftest ^{:task 1 :task-1 true} clean-empty-string
   (is (= "" (squeaky-clean/clean ""))))
 
-(deftest ^{:task 2} clean-string-with-control-char
+(deftest ^{:task 2 :task-2 true} clean-string-with-control-char
   (is (= "myCTRLId" (squeaky-clean/clean "my\u0080Id"))))
 
-(deftest ^{:task 3} convert-kebab-to-camel-case
+(deftest ^{:task 3 :task-3 true} convert-kebab-to-camel-case
   (is (= "àḂç" (squeaky-clean/clean "à-ḃç"))))
 
-(deftest ^{:task 4} clean-string-with-special-characters
+(deftest ^{:task 4 :task-4 true} clean-string-with-special-characters
   (is (= "MyFinder" (squeaky-clean/clean "My😀😀Finder😀"))))
 
-(deftest ^{:task 4} clean-string-with-numbers
+(deftest ^{:task 4 :task-4 true} clean-string-with-numbers
   (is (= "MyFinder" (squeaky-clean/clean "1My2Finder3"))))
 
-(deftest ^{:task 5} omit-lower-case-greek-letters
+(deftest ^{:task 5 :task-5 true} omit-lower-case-greek-letters
   (is (= "MyΟFinder" (squeaky-clean/clean "MyΟβιεγτFinder"))))
 
-(deftest ^{:task 5} combine-conversions
+(deftest ^{:task 5 :task-5 true} combine-conversions
   (is (= "_AbcĐCTRL" (squeaky-clean/clean "9 -abcĐ😀ω\0"))))


### PR DESCRIPTION
As discussed in https://github.com/exercism/clojure/issues/783

Note: I haven't added the selector `:clean`, as `clean` is the only tested function